### PR TITLE
Add pip-installable travel-seg Python bindings (Phase 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,16 @@ cmake-build-debug*
 build/
 build_*/
 
+# Python
+__pycache__/
+*.pyc
+.pytest_cache/
+*.egg-info/
+dist/
+wheels/
+.venv/
+.python-version
+
 # Created by https://www.gitignore.io/api/c++,code,cmake,eclipse
 # Edit at https://www.gitignore.io/?templates=c++,code,cmake,eclipse
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Object segmentation, Traversable ground segmentation, Graph search, Autonomous n
 
 ## Repository Layout
 
-The repo is split so the algorithm core can be consumed without ROS.
+The repo is split so the algorithm core can be consumed without ROS or even without C++ tooling.
 
 ```
 TRAVEL/
@@ -26,6 +26,9 @@ TRAVEL/
 │   │   ├── core/travel/{tgs,aos,point_types,save_labels,kitti_loader,logging}.hpp
 │   │   └── core/travel/3rdparty/nanoflann*.hpp
 │   └── examples/      # Standalone CLI demo (run_travel_kitti). No ROS.
+├── python/            # pip-installable bindings (travel-seg).
+│   ├── pyproject.toml, CMakeLists.txt
+│   └── travel_seg/    # numpy-friendly Python API on top of the C++ core
 └── ros/               # ROS1 (catkin) wrapper that consumes cpp/travel/.
     └── src/main.cpp, msg/, launch/, config/, rviz/
 ```
@@ -35,6 +38,28 @@ TRAVEL/
 - ROS wrapper (`ros/`): Ubuntu 18.04 / ROS Melodic (original target). Newer combos (Ubuntu 20.04 / Noetic) should work but are not regression-tested.
 
 ## How to Build
+
+### Python (pip)
+
+```
+# Ubuntu deps:  sudo apt install build-essential cmake libeigen3-dev libpcl-dev libboost-system-dev libboost-filesystem-dev
+# macOS deps:   brew install cmake eigen boost pcl
+
+git clone https://github.com/url-kaist/TRAVEL.git
+cd TRAVEL
+pip install -e python/   # editable; rebuilds C++ on next import if changed
+```
+
+Quick start:
+
+```python
+import numpy as np, travel_seg as ts
+points = np.fromfile("0000.bin", dtype=np.float32).reshape(-1, 4)
+result = ts.segment(points)            # SegmentResult
+ground_pts = points[result.ground_mask]
+```
+
+See `python/README.md` for the full API.
 
 ### Core library + standalone example (no ROS)
 
@@ -83,8 +108,8 @@ roslaunch travel travel_run.launch
 5. Use `ObjectCluster::segmentObjects()` for above-ground object segmentation.
 6. Logging in the core is routed through `TRAVEL_LOG_*` macros (in `travel/logging.hpp`). Define `TRAVEL_USE_ROS_LOGGING` at compile time to dispatch to ROS_INFO/WARN/ERROR; otherwise output goes to stdout/stderr.
 
-* If you want to use TRAVEL with python code, then visit here (https://github.com/darrenjkt/TRAVEL). Thank you Darren :)
-* `pip install travel-seg` Python bindings are planned (Phase 2).
+* `pip install travel-seg` is now supported via `python/`. See `python/README.md`.
+* For the previous third-party Python wrapper, see https://github.com/darrenjkt/TRAVEL. Thank you Darren :)
 
 ## Citation
 If our research has been helpful, please cite the below papers:

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,0 +1,69 @@
+cmake_minimum_required(VERSION 3.16...3.31)
+project(travel_seg_pybind LANGUAGES CXX)
+
+set(CMAKE_BUILD_TYPE Release)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+include(FetchContent)
+FetchContent_Declare(
+    pybind11
+    GIT_REPOSITORY https://github.com/pybind/pybind11
+    GIT_TAG master
+)
+FetchContent_MakeAvailable(pybind11)
+
+set(PYBIND11_NEWPYTHON ON)
+find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
+
+# Dual-mode integration:
+#   In-tree dev (`pip install -e python/` from the repo): use the local
+#   `cpp/travel/` tree directly via add_subdirectory.
+#   Out-of-tree (`pip install travel-seg` from PyPI sdist): the `cpp/`
+#   sibling directory is not present, so fetch the released TRAVEL repo
+#   and consume its `cpp/travel` subdir via FetchContent SOURCE_SUBDIR.
+if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../cpp/travel/CMakeLists.txt)
+    message(STATUS "Building travel_seg pybind module against local cpp/travel tree")
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../cpp/travel
+                     ${CMAKE_CURRENT_BINARY_DIR}/travel_core)
+else()
+    cmake_minimum_required(VERSION 3.18)
+    message(STATUS "Out-of-tree build: fetching TRAVEL v${CMAKE_PROJECT_VERSION} from GitHub")
+    FetchContent_Declare(
+        ext_travel_core PREFIX travel_core
+        GIT_REPOSITORY https://github.com/url-kaist/TRAVEL
+        GIT_TAG main
+        SOURCE_SUBDIR cpp/travel
+    )
+    FetchContent_MakeAvailable(ext_travel_core)
+endif()
+
+# Compiled extension. The leading underscore keeps it private — `__init__.py`
+# re-exports the public surface so users can write `import travel_seg as ts`
+# and never see the binding module directly.
+set(OUTPUT_MODULE_NAME _travel_seg)
+
+pybind11_add_module(${OUTPUT_MODULE_NAME}
+    travel_seg/pybind/travel_pybind.cpp
+)
+target_link_libraries(${OUTPUT_MODULE_NAME} PUBLIC travel::travel_core)
+
+# Silence third-party warnings (PCL / Eigen) inside the binding shim.
+target_compile_options(${OUTPUT_MODULE_NAME} PRIVATE
+    $<$<CXX_COMPILER_ID:GNU>:-w>
+    $<$<CXX_COMPILER_ID:Clang>:-w>
+    $<$<CXX_COMPILER_ID:AppleClang>:-w>
+    $<$<CXX_COMPILER_ID:MSVC>:/w>
+)
+
+# pybind11 + clang quirk; harmless on GCC.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"
+    OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+    target_compile_options(${OUTPUT_MODULE_NAME} PUBLIC -fsized-deallocation)
+endif()
+
+# Install the .so inside the package directory so it is importable as
+# `travel_seg._travel_seg`.
+install(TARGETS ${OUTPUT_MODULE_NAME} DESTINATION travel_seg)

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,86 @@
+# travel-seg
+
+Python bindings for [TRAVEL](https://github.com/url-kaist/TRAVEL) — traversable ground and above-ground object segmentation for 3D LiDAR scans.
+
+## Install
+
+### From source (development)
+
+```bash
+# System deps (Ubuntu)
+sudo apt install build-essential cmake libeigen3-dev libpcl-dev \
+                 libboost-system-dev libboost-filesystem-dev
+
+# System deps (macOS)
+brew install cmake eigen boost pcl
+
+git clone https://github.com/url-kaist/TRAVEL.git
+cd TRAVEL
+pip install -e python/
+```
+
+### From PyPI (planned)
+
+```bash
+pip install travel-seg
+```
+
+The PyPI sdist's `python/CMakeLists.txt` falls back to `FetchContent` for the C++ core, so no separate clone is needed.
+
+## Usage
+
+```python
+import numpy as np
+import travel_seg as ts
+
+# KITTI .bin → (N, 4) float32 XYZI
+points = np.fromfile("0000.bin", dtype=np.float32).reshape(-1, 4)
+
+# One-shot
+result = ts.segment(points)
+ground_pts = points[result.ground_mask]
+for cid in np.unique(result.instance_labels):
+    if cid == 0:
+        continue
+    cluster_pts = points[result.instance_labels == cid]
+    print(f"cluster {cid}: {len(cluster_pts)} points")
+
+# Per-frame loops: build the segmenters once, reuse
+tgs = ts.TravelGroundSeg(ts.GroundSegConfig(max_range=80.0))
+aos = ts.ObjectCluster(ts.ObjectClusterConfig(vert_scan=64, horz_scan=4500))
+for frame in frames:
+    ground_mask, elapsed = tgs.estimate_ground(frame[:, :3])
+    labels = aos.segment_objects(frame[~ground_mask, :3])
+    ...
+```
+
+## API
+
+| Symbol | Purpose |
+|---|---|
+| `GroundSegConfig`     | dataclass — TGS parameters; KITTI-tuned defaults |
+| `ObjectClusterConfig` | dataclass — AOS parameters; KITTI-tuned defaults |
+| `TravelGroundSeg(cfg)` | reusable ground segmenter; `.estimate_ground(points) -> (mask, elapsed)` |
+| `ObjectCluster(cfg)`   | reusable object clusterer; `.segment_objects(points) -> labels` |
+| `segment(points, ground_config=None, object_config=None)` | one-shot helper returning a `SegmentResult` |
+| `SegmentResult`        | dataclass: `.ground_mask`, `.instance_labels`, `.elapsed_seconds` |
+
+Inputs are float32 numpy arrays of shape `(N, 3)` (XYZ) or `(N, 4)` (XYZI). The intensity column is currently ignored by both TGS and AOS but accepted for convenience when reading raw KITTI bins.
+
+Outputs are length-N numpy arrays aligned with the original input order:
+- `ground_mask`: `bool`, `True` where the input point was classified as ground.
+- `instance_labels`: `int32`. `0` = ground / unclassified / dropped. `1..K` = per-cluster ids within this single frame (not consistent across frames).
+
+## Tests / examples
+
+```bash
+pip install -e python/[test]
+pytest python/tests/
+
+# Real data demo
+python python/examples/run_kitti.py /path/to/kitti/sequences/00 0 /tmp/out
+```
+
+## Citation
+
+See the top-level [README](../README.md).

--- a/python/examples/run_kitti.py
+++ b/python/examples/run_kitti.py
@@ -1,0 +1,73 @@
+"""Python mirror of cpp/examples/run_travel_kitti.cpp.
+
+Reads a single KITTI velodyne scan, runs ground + object segmentation, and
+prints summary statistics. Optionally writes per-class .npy files for
+inspection.
+
+Usage:
+    python run_kitti.py <kitti_seq_dir> [frame_index] [output_dir]
+
+    <kitti_seq_dir>  directory containing velodyne/<XXXXXX>.bin
+    [frame_index]    0-based frame index (default 0)
+    [output_dir]     if given, writes <prefix>_ground.npy / _nonground.npy /
+                     _labels.npy (one int32 label per input point)
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+import travel_seg as ts
+
+
+def load_kitti_bin(seq_dir: Path, frame_idx: int) -> np.ndarray:
+    """Load a single KITTI velodyne_points/data .bin file as float32 (N, 4)."""
+    path = seq_dir / "velodyne" / f"{frame_idx:06d}.bin"
+    if not path.exists():
+        raise FileNotFoundError(f"velodyne frame not found: {path}")
+    return np.fromfile(path, dtype=np.float32).reshape(-1, 4)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print(__doc__, file=sys.stderr)
+        return 1
+
+    seq_dir    = Path(argv[1])
+    frame_idx  = int(argv[2]) if len(argv) > 2 else 0
+    output_dir = Path(argv[3]) if len(argv) > 3 else None
+
+    points = load_kitti_bin(seq_dir, frame_idx)
+    print(f"Loaded {points.shape[0]} points from {seq_dir.name} frame {frame_idx}")
+
+    t0 = time.perf_counter()
+    result = ts.segment(points[:, :3])
+    wall = time.perf_counter() - t0
+
+    ground_n    = int(result.ground_mask.sum())
+    nonground_n = int((~result.ground_mask).sum())
+    cluster_ids = np.unique(result.instance_labels)
+    cluster_n   = int((cluster_ids > 0).sum())
+    print(
+        f"  ground: {ground_n} | nonground: {nonground_n} | "
+        f"clusters: {cluster_n} | tgs: {result.elapsed_seconds*1000:.1f} ms | "
+        f"wall: {wall*1000:.1f} ms"
+    )
+
+    if output_dir is not None:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        prefix = output_dir / f"{frame_idx:06d}"
+        np.save(prefix.with_suffix(".ground.npy"),    points[result.ground_mask])
+        np.save(prefix.with_suffix(".nonground.npy"), points[~result.ground_mask])
+        np.save(prefix.with_suffix(".labels.npy"),    result.instance_labels)
+        print(f"  wrote {prefix.parent}/{prefix.name}.{{ground,nonground,labels}}.npy")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,49 @@
+[build-system]
+requires = ["scikit_build_core", "pybind11"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "travel-seg"
+version = "0.1.0"
+requires-python = ">=3.8"
+description = "Python bindings for TRAVEL: traversable ground and above-ground object segmentation for 3D LiDAR scans"
+readme = "README.md"
+license = { text = "GPL-3.0-or-later" }
+authors = [
+    { name = "Hyungtae Lim", email = "shapelim@mit.edu" },
+    { name = "Minho Oh", email = "dhalsgh03@gmail.com" },
+    { name = "Euigon Jung", email = "egjung94@gmail.com" },
+]
+classifiers = [
+    "Programming Language :: C++",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS",
+    "Topic :: Scientific/Engineering",
+    "Intended Audience :: Science/Research",
+]
+keywords = ["lidar", "point-cloud", "segmentation", "ground-segmentation", "robotics"]
+dependencies = [
+    "numpy",
+]
+
+[project.urls]
+Homepage = "https://github.com/url-kaist/TRAVEL"
+Repository = "https://github.com/url-kaist/TRAVEL"
+"Bug Tracker" = "https://github.com/url-kaist/TRAVEL/issues"
+
+[project.optional-dependencies]
+test = ["pytest"]
+
+[tool.scikit-build]
+wheel.packages = ["travel_seg"]
+# `python/CMakeLists.txt` uses `FetchContent_Declare(... SOURCE_SUBDIR ...)` in
+# the out-of-tree (sdist / PyPI) path, which requires CMake 3.18+. Ubuntu 20.04
+# ships CMake 3.16, so let scikit-build-core provision a newer cmake from the
+# `cmake` PyPI wheel when the system one is too old.
+cmake.version = ">=3.18,<4"

--- a/python/tests/test_smoke.py
+++ b/python/tests/test_smoke.py
@@ -1,0 +1,139 @@
+"""Smoke tests for travel_seg.
+
+Goal: prove the binding builds, imports, and runs end-to-end on synthetic
+data — not to validate algorithmic quality. Numerical correctness on KITTI
+is covered by examples/run_kitti.py against real data.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import travel_seg as ts
+
+
+def _synthetic_scene(n_ground: int = 40_000,
+                     n_objects: int = 8_000,
+                     seed: int = 0) -> np.ndarray:
+    """A flat ground plane plus a few box-shaped clusters above it.
+
+    Range is roughly 5..40 m so it lands inside the default
+    ``GroundSegConfig`` / ``ObjectClusterConfig`` ranges.
+    """
+    rng = np.random.default_rng(seed)
+
+    ground = np.zeros((n_ground, 3), dtype=np.float32)
+    ground[:, 0] = rng.uniform(-30.0, 30.0, n_ground)
+    ground[:, 1] = rng.uniform(-30.0, 30.0, n_ground)
+    ground[:, 2] = rng.normal(0.0, 0.02, n_ground)
+
+    object_pts = []
+    centers = [(8, 0, 1.0), (-6, 4, 0.8), (3, -10, 1.2), (15, 5, 1.5)]
+    per_box = n_objects // len(centers)
+    for cx, cy, cz in centers:
+        box = np.zeros((per_box, 3), dtype=np.float32)
+        box[:, 0] = cx + rng.uniform(-0.6, 0.6, per_box)
+        box[:, 1] = cy + rng.uniform(-0.6, 0.6, per_box)
+        box[:, 2] = rng.uniform(0.2, cz + 0.5, per_box)
+        object_pts.append(box)
+    objects = np.concatenate(object_pts, axis=0)
+
+    pts = np.concatenate([ground, objects], axis=0)
+    rng.shuffle(pts)
+    return pts
+
+
+def test_module_metadata():
+    assert hasattr(ts, "__version__")
+    assert callable(ts.segment)
+
+
+def test_segment_returns_correct_shapes():
+    points = _synthetic_scene()
+    result = ts.segment(points)
+
+    assert isinstance(result, ts.SegmentResult)
+    assert result.ground_mask.shape == (points.shape[0],)
+    assert result.ground_mask.dtype == np.bool_
+    assert result.instance_labels.shape == (points.shape[0],)
+    assert result.instance_labels.dtype == np.int32
+    assert isinstance(result.elapsed_seconds, float)
+    assert result.elapsed_seconds >= 0.0
+
+
+def test_ground_segmentation_finds_ground_points():
+    points = _synthetic_scene()
+    result = ts.segment(points)
+
+    # The synthetic ground plane has |z| ~ 0; the boxes are at z >= 0.2. So
+    # most low-z points should land in ground_mask, and most high-z points
+    # should not. We don't require a perfect classifier here, just that the
+    # algorithm is producing sensibly correlated output.
+    low_z = points[:, 2] < 0.05
+    high_z = points[:, 2] > 0.5
+
+    ground_recall_lowz = result.ground_mask[low_z].mean() if low_z.any() else 0.0
+    ground_in_highz    = result.ground_mask[high_z].mean() if high_z.any() else 0.0
+
+    assert ground_recall_lowz > 0.5, (
+        f"expected most low-z points to be ground, got {ground_recall_lowz:.2%}")
+    assert ground_in_highz < 0.5, (
+        f"expected most high-z points to not be ground, got {ground_in_highz:.2%}")
+
+
+def test_object_clustering_produces_multiple_clusters():
+    points = _synthetic_scene()
+    result = ts.segment(points)
+
+    cluster_ids = np.unique(result.instance_labels)
+    nonzero = cluster_ids[cluster_ids > 0]
+    # We seeded 4 well-separated boxes; expect at least a couple of clusters.
+    assert len(nonzero) >= 2, (
+        f"expected multiple clusters from 4 boxes, got ids {cluster_ids}")
+
+
+def test_xyz_and_xyzi_inputs_both_accepted():
+    points_xyz = _synthetic_scene()
+    intensity  = np.zeros((points_xyz.shape[0], 1), dtype=np.float32)
+    points_xyzi = np.concatenate([points_xyz, intensity], axis=1)
+
+    r_xyz  = ts.segment(points_xyz)
+    r_xyzi = ts.segment(points_xyzi)
+
+    # Ground segmentation is deterministic; cluster id assignment is not
+    # (AOS::labelPointcloud uses std::random_device to shuffle ids), so we
+    # check structural equivalence instead of bit-identity for the labels.
+    np.testing.assert_array_equal(r_xyz.ground_mask, r_xyzi.ground_mask)
+
+    labeled_xyz  = r_xyz.instance_labels  > 0
+    labeled_xyzi = r_xyzi.instance_labels > 0
+    np.testing.assert_array_equal(labeled_xyz, labeled_xyzi)
+    assert len(np.unique(r_xyz.instance_labels[labeled_xyz])) == \
+           len(np.unique(r_xyzi.instance_labels[labeled_xyzi]))
+
+
+def test_class_api_matches_convenience_function():
+    points = _synthetic_scene()
+
+    tgs = ts.TravelGroundSeg()
+    aos = ts.ObjectCluster()
+
+    ground_mask, _ = tgs.estimate_ground(points)
+    instance_labels = np.zeros(points.shape[0], dtype=np.int32)
+    nonground = points[~ground_mask]
+    if len(nonground) > 0:
+        instance_labels[~ground_mask] = aos.segment_objects(nonground)
+
+    result = ts.segment(points)
+    # Ground segmentation is deterministic; cluster ids are not (see above),
+    # so compare ground equality and labeled-vs-unlabeled membership only.
+    np.testing.assert_array_equal(ground_mask, result.ground_mask)
+    np.testing.assert_array_equal(instance_labels > 0, result.instance_labels > 0)
+
+
+def test_invalid_input_shape_raises():
+    with pytest.raises(ValueError):
+        ts.segment(np.zeros(100, dtype=np.float32))
+    with pytest.raises(ValueError):
+        ts.segment(np.zeros((100, 5), dtype=np.float32))

--- a/python/travel_seg/__init__.py
+++ b/python/travel_seg/__init__.py
@@ -1,0 +1,32 @@
+"""travel_seg — Python bindings for the TRAVEL ground / object segmenter.
+
+Quick start::
+
+    import numpy as np
+    import travel_seg as ts
+
+    points = np.fromfile("0000.bin", dtype=np.float32).reshape(-1, 4)
+    result = ts.segment(points)
+
+    ground_pts = points[result.ground_mask]
+    for cluster_id in np.unique(result.instance_labels):
+        if cluster_id == 0:
+            continue
+        cluster_pts = points[result.instance_labels == cluster_id]
+        ...
+"""
+
+from ._api import ObjectCluster, TravelGroundSeg, segment
+from ._config import GroundSegConfig, ObjectClusterConfig, SegmentResult
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "GroundSegConfig",
+    "ObjectClusterConfig",
+    "SegmentResult",
+    "TravelGroundSeg",
+    "ObjectCluster",
+    "segment",
+    "__version__",
+]

--- a/python/travel_seg/_api.py
+++ b/python/travel_seg/_api.py
@@ -1,0 +1,197 @@
+"""User-facing Python API for travel_seg.
+
+Wraps the compiled ``_travel_seg`` module in idiomatic Python classes that
+take dataclass configs and return numpy arrays (instead of the C++ idiom of
+output references and PCL point clouds).
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import numpy as np
+
+from ._config import GroundSegConfig, ObjectClusterConfig, SegmentResult
+
+
+def _backend():
+    # Lazy import so a missing/failed binding produces a useful traceback at
+    # the call site instead of at module import time.
+    try:
+        from . import _travel_seg as backend
+    except ImportError:
+        import _travel_seg as backend  # editable / non-installed fallback
+    return backend
+
+
+def _ensure_xyz_or_xyzi_float32(points: np.ndarray) -> np.ndarray:
+    arr = np.asarray(points)
+    if arr.ndim != 2:
+        raise ValueError(f"expected 2D array, got {arr.ndim}D with shape {arr.shape}")
+    if arr.shape[1] not in (3, 4):
+        raise ValueError(
+            f"expected (N, 3) for XYZ or (N, 4) for XYZI, got shape {arr.shape}"
+        )
+    if arr.dtype != np.float32:
+        arr = arr.astype(np.float32, copy=False)
+    if not arr.flags["C_CONTIGUOUS"]:
+        arr = np.ascontiguousarray(arr)
+    return arr
+
+
+class TravelGroundSeg:
+    """Traversable ground segmentation.
+
+    Reuses internal state across calls, so creating the instance once and
+    calling ``estimate_ground`` per frame is faster than going through
+    :func:`segment` (which builds a fresh instance every call).
+    """
+
+    def __init__(self, config: Optional[GroundSegConfig] = None):
+        self._config = config if config is not None else GroundSegConfig()
+        self._impl = _backend()._TravelGroundSeg()
+        self._apply_config()
+
+    def _apply_config(self) -> None:
+        c = self._config
+        self._impl.set_params(
+            max_range=c.max_range,
+            min_range=c.min_range,
+            resolution=c.resolution,
+            num_iter=c.num_iter,
+            num_lpr=c.num_lpr,
+            num_min_pts=c.num_min_pts,
+            th_seeds=c.th_seeds,
+            th_dist=c.th_dist,
+            th_outlier=c.th_outlier,
+            th_normal=c.th_normal,
+            th_weight=c.th_weight,
+            th_lcc_normal=c.th_lcc_normal,
+            th_lcc_planar=c.th_lcc_planar,
+            th_obstacle=c.th_obstacle,
+            refine_mode=c.refine_mode,
+        )
+
+    @property
+    def config(self) -> GroundSegConfig:
+        return self._config
+
+    @config.setter
+    def config(self, value: GroundSegConfig) -> None:
+        self._config = value
+        self._apply_config()
+
+    def estimate_ground(self, points: np.ndarray) -> Tuple[np.ndarray, float]:
+        """Run TGS on a single frame.
+
+        Parameters
+        ----------
+        points:
+            ``float32`` numpy array of shape ``(N, 3)`` (XYZ) or
+            ``(N, 4)`` (XYZI). Mixed dtypes are silently cast.
+
+        Returns
+        -------
+        (ground_mask, elapsed_seconds):
+            ``ground_mask`` is a ``bool`` array of length ``N``; ``True``
+            wherever the corresponding input point was classified as ground.
+            ``elapsed_seconds`` is wall-clock time spent inside the C++
+            algorithm.
+        """
+        return self._impl.estimate_ground(_ensure_xyz_or_xyzi_float32(points))
+
+
+class ObjectCluster:
+    """Above-ground object segmentation (instance clustering)."""
+
+    def __init__(self, config: Optional[ObjectClusterConfig] = None):
+        self._config = config if config is not None else ObjectClusterConfig()
+        self._impl = _backend()._ObjectCluster()
+        self._apply_config()
+
+    def _apply_config(self) -> None:
+        c = self._config
+        self._impl.set_params(
+            vert_scan=c.vert_scan,
+            horz_scan=c.horz_scan,
+            min_range=c.min_range,
+            max_range=c.max_range,
+            min_vert_angle=c.min_vert_angle,
+            max_vert_angle=c.max_vert_angle,
+            horz_merge_thres=c.horz_merge_thres,
+            vert_merge_thres=c.vert_merge_thres,
+            vert_scan_size=c.vert_scan_size,
+            horz_scan_size=c.horz_scan_size,
+            horz_extension_size=c.horz_extension_size,
+            horz_skip_size=c.horz_skip_size,
+            downsample=c.downsample,
+            min_cluster_size=c.min_cluster_size,
+            max_cluster_size=c.max_cluster_size,
+        )
+
+    @property
+    def config(self) -> ObjectClusterConfig:
+        return self._config
+
+    @config.setter
+    def config(self, value: ObjectClusterConfig) -> None:
+        self._config = value
+        self._apply_config()
+
+    def segment_objects(self, points: np.ndarray) -> np.ndarray:
+        """Cluster the given (typically non-ground) points.
+
+        Parameters
+        ----------
+        points:
+            ``float32`` numpy array of shape ``(M, 3)`` (XYZ) or
+            ``(M, 4)`` (XYZI).
+
+        Returns
+        -------
+        instance_labels:
+            ``int32`` array of length ``M``. ``0`` means the point was not
+            assigned to any cluster (e.g. dropped by AOS range /
+            downsample / cluster-size filters). Positive ids are unique
+            within this single frame.
+        """
+        return self._impl.segment_objects(_ensure_xyz_or_xyzi_float32(points))
+
+
+def segment(
+    points: np.ndarray,
+    ground_config: Optional[GroundSegConfig] = None,
+    object_config: Optional[ObjectClusterConfig] = None,
+) -> SegmentResult:
+    """One-shot TGS + AOS over a single frame.
+
+    Equivalent to::
+
+        tgs = TravelGroundSeg(ground_config)
+        aos = ObjectCluster(object_config)
+        ground_mask, t = tgs.estimate_ground(points)
+        labels = np.zeros(len(points), dtype=np.int32)
+        labels[~ground_mask] = aos.segment_objects(points[~ground_mask])
+
+    For per-frame loops, prefer constructing :class:`TravelGroundSeg` and
+    :class:`ObjectCluster` once and reusing them; this convenience function
+    rebuilds both on every call.
+    """
+    points = _ensure_xyz_or_xyzi_float32(points)
+
+    tgs = TravelGroundSeg(ground_config)
+    aos = ObjectCluster(object_config)
+
+    ground_mask, elapsed = tgs.estimate_ground(points)
+
+    instance_labels = np.zeros(points.shape[0], dtype=np.int32)
+    nonground_idx = np.flatnonzero(~ground_mask)
+    if nonground_idx.size > 0:
+        nonground_labels = aos.segment_objects(points[nonground_idx])
+        instance_labels[nonground_idx] = nonground_labels
+
+    return SegmentResult(
+        ground_mask=ground_mask,
+        instance_labels=instance_labels,
+        elapsed_seconds=elapsed,
+    )

--- a/python/travel_seg/_config.py
+++ b/python/travel_seg/_config.py
@@ -1,0 +1,74 @@
+"""Configuration dataclasses and result types for travel_seg.
+
+Defaults mirror ``ros/config/kitti_params.yaml`` so the Python API gives
+sensible behaviour on KITTI-style 64-channel scans out of the box.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass
+class GroundSegConfig:
+    """Parameters for traversable ground segmentation (TGS)."""
+    max_range: float = 80.0
+    min_range: float = 1.0
+    resolution: float = 8.0
+    num_iter: int = 3
+    num_lpr: int = 5
+    num_min_pts: int = 10
+    th_seeds: float = 0.5
+    th_dist: float = 0.125
+    th_outlier: float = 0.3
+    th_normal: float = 0.940
+    th_weight: float = 200.0
+    th_lcc_normal: float = 0.03
+    th_lcc_planar: float = 0.1
+    th_obstacle: float = 1.0
+    refine_mode: bool = True
+
+
+@dataclass
+class ObjectClusterConfig:
+    """Parameters for above-ground object segmentation / clustering (AOS)."""
+    vert_scan: int = 64
+    horz_scan: int = 4500
+    min_range: float = 1.0
+    max_range: float = 80.0
+    min_vert_angle: float = -24.8
+    max_vert_angle: float = 2.0
+    horz_merge_thres: float = 0.4
+    vert_merge_thres: float = 0.5
+    vert_scan_size: int = 3
+    horz_scan_size: int = 5
+    horz_extension_size: int = 5
+    horz_skip_size: int = 5
+    downsample: int = 1
+    min_cluster_size: int = 10
+    max_cluster_size: int = 30000
+
+
+@dataclass
+class SegmentResult:
+    """Result of a one-shot ``travel_seg.segment(points)`` call.
+
+    Attributes
+    ----------
+    ground_mask:
+        Boolean array of length ``N`` (= number of input points). ``True``
+        where the corresponding input point was classified as ground.
+    instance_labels:
+        ``int32`` array of length ``N``. ``0`` means the point was either
+        ground or fell outside any cluster (e.g. trimmed by AOS range /
+        downsample / cluster-size filters). ``1..K`` are per-cluster ids
+        within this single frame; ids are not consistent across frames.
+    elapsed_seconds:
+        Wall-clock time spent in the C++ ground segmentation step. Object
+        clustering time is currently not reported separately.
+    """
+    ground_mask: np.ndarray
+    instance_labels: np.ndarray
+    elapsed_seconds: float

--- a/python/travel_seg/pybind/travel_pybind.cpp
+++ b/python/travel_seg/pybind/travel_pybind.cpp
@@ -1,0 +1,243 @@
+// pybind11 bindings for TRAVEL ground / object segmentation.
+//
+// Design notes:
+// - The C++ algorithm classes are templated on a custom point type
+//   (PointXYZILID) that carries XYZ + intensity + label + id. Python users
+//   work with plain numpy arrays of shape (N, 3) or (N, 4), so this module
+//   handles the conversion both ways.
+// - estimateGround() and segmentObjects() return *new* point clouds, not
+//   per-input-index labels. The bindings reconstruct the per-input mapping
+//   via a kd-tree nearest-neighbour lookup against the ORIGINAL input cloud
+//   (squared-distance epsilon ~ 1e-5). This mirrors what the C++
+//   `saveLabels()` helper already does for KITTI .label exports.
+// - segmentObjects() mutates its input cloud in-place (sphericalProjection
+//   does `*cloud_in = *valid_cloud`). The binding makes a defensive copy of
+//   the original input before passing it in, so the lookup is against the
+//   pristine cloud.
+
+#define PCL_NO_PRECOMPILE
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+
+#include "travel/3rdparty/nanoflann.hpp"
+#include "travel/3rdparty/nanoflann_utils.hpp"
+#include "travel/aos.hpp"
+#include "travel/point_types.hpp"
+#include "travel/tgs.hpp"
+
+namespace py = pybind11;
+using namespace py::literals;
+
+namespace {
+
+using Cloud    = pcl::PointCloud<PointXYZILID>;
+using CloudPtr = Cloud::Ptr;
+
+// Convert numpy [N,3] (XYZ) or [N,4] (XYZI) float32 array -> PCL cloud.
+CloudPtr numpyToCloud(py::array_t<float, py::array::c_style | py::array::forcecast> arr) {
+    auto info = arr.request();
+    if (info.ndim != 2) {
+        throw std::invalid_argument(
+            "expected 2D float32 array, got " + std::to_string(info.ndim) + "D");
+    }
+    if (info.shape[1] != 3 && info.shape[1] != 4) {
+        throw std::invalid_argument(
+            "expected (N, 3) for XYZ or (N, 4) for XYZI, got shape (" +
+            std::to_string(info.shape[0]) + ", " + std::to_string(info.shape[1]) + ")");
+    }
+    const ssize_t N    = info.shape[0];
+    const ssize_t cols = info.shape[1];
+    const float*  data = static_cast<const float*>(info.ptr);
+
+    CloudPtr cloud(new Cloud());
+    cloud->reserve(static_cast<size_t>(N));
+    for (ssize_t i = 0; i < N; ++i) {
+        PointXYZILID p{};
+        p.x         = data[i * cols + 0];
+        p.y         = data[i * cols + 1];
+        p.z         = data[i * cols + 2];
+        p.intensity = (cols == 4) ? data[i * cols + 3] : 0.0f;
+        p.label     = 0;
+        p.id        = 0;
+        cloud->push_back(p);
+    }
+    return cloud;
+}
+
+// Wrap an XYZ kd-tree built from a PCL cloud's coordinates so we can ask
+// "for each query point, was there an identical (eps-close) reference?".
+class XyzKdTree {
+public:
+    explicit XyzKdTree(const Cloud& ref) {
+        pts_.pts.resize(ref.size());
+        for (size_t i = 0; i < ref.size(); ++i) {
+            pts_.pts[i].x = ref[i].x;
+            pts_.pts[i].y = ref[i].y;
+            pts_.pts[i].z = ref[i].z;
+        }
+        index_ = std::make_unique<KdTree>(3, pts_, kdtree_params_);
+    }
+
+    // Returns (found, ref_index) for the single nearest neighbour.
+    bool nearest(float x, float y, float z, float eps_sq, uint32_t& out_idx) const {
+        if (pts_.pts.empty()) return false;
+        const float pt[3] = {x, y, z};
+        size_t   num_results = 1;
+        uint32_t ret_idx     = 0;
+        float    out_dist_sq = 0.f;
+        num_results = index_->knnSearch(pt, num_results, &ret_idx, &out_dist_sq);
+        if (num_results > 0 && out_dist_sq < eps_sq) {
+            out_idx = ret_idx;
+            return true;
+        }
+        return false;
+    }
+
+private:
+    using KdTree = nanoflann::KDTreeSingleIndexAdaptor<
+        nanoflann::L2_Simple_Adaptor<float, PointCloud<float>>,
+        PointCloud<float>,
+        3>;
+
+    PointCloud<float>       pts_;
+    nanoflann::KDTreeSingleIndexAdaptorParams kdtree_params_{10};
+    std::unique_ptr<KdTree> index_;
+};
+
+constexpr float kEpsSq = 1e-5f;  // Same threshold as travel::saveLabels.
+
+// Build a bool[N] mask: true where each query point has a match in `ref`.
+py::array_t<bool> maskByNearest(const Cloud& ref, const Cloud& query) {
+    XyzKdTree tree(ref);
+    py::array_t<bool> result(static_cast<py::ssize_t>(query.size()));
+    auto buf = result.mutable_unchecked<1>();
+    uint32_t idx = 0;
+    for (size_t i = 0; i < query.size(); ++i) {
+        buf(i) = tree.nearest(query[i].x, query[i].y, query[i].z, kEpsSq, idx);
+    }
+    return result;
+}
+
+// Build an int32[N] label array: copy `ref[match].id` for matched query
+// points, leave 0 otherwise.
+py::array_t<int32_t> labelByNearest(const Cloud& ref, const Cloud& query) {
+    XyzKdTree tree(ref);
+    py::array_t<int32_t> result(static_cast<py::ssize_t>(query.size()));
+    auto buf = result.mutable_unchecked<1>();
+    uint32_t idx = 0;
+    for (size_t i = 0; i < query.size(); ++i) {
+        if (tree.nearest(query[i].x, query[i].y, query[i].z, kEpsSq, idx)) {
+            buf(i) = static_cast<int32_t>(ref[idx].id);
+        } else {
+            buf(i) = 0;
+        }
+    }
+    return result;
+}
+
+}  // namespace
+
+PYBIND11_MODULE(_travel_seg, m) {
+    m.doc() =
+        "pybind11 bindings for the TRAVEL traversable-ground / object "
+        "segmentation library.";
+    m.attr("__version__") = "0.1.0";
+
+    // -- TravelGroundSeg ------------------------------------------------------
+    py::class_<travel::TravelGroundSeg<PointXYZILID>>(m, "_TravelGroundSeg")
+        .def(py::init<>())
+        .def("set_params",
+             [](travel::TravelGroundSeg<PointXYZILID>& self,
+                double max_range, double min_range, double resolution,
+                int    num_iter,  int    num_lpr,    int    num_min_pts,
+                double th_seeds,  double th_dist,    double th_outlier,
+                double th_normal, double th_weight,
+                double th_lcc_normal, double th_lcc_planar, double th_obstacle,
+                bool   refine_mode) {
+                 self.setParams(max_range, min_range, resolution,
+                                num_iter, num_lpr, num_min_pts,
+                                th_seeds, th_dist, th_outlier,
+                                th_normal, th_weight,
+                                th_lcc_normal, th_lcc_planar, th_obstacle,
+                                refine_mode, /*viz_mode=*/false);
+             },
+             "max_range"_a, "min_range"_a, "resolution"_a,
+             "num_iter"_a, "num_lpr"_a, "num_min_pts"_a,
+             "th_seeds"_a, "th_dist"_a, "th_outlier"_a,
+             "th_normal"_a, "th_weight"_a,
+             "th_lcc_normal"_a, "th_lcc_planar"_a, "th_obstacle"_a,
+             "refine_mode"_a)
+        .def("estimate_ground",
+             [](travel::TravelGroundSeg<PointXYZILID>& self,
+                py::array_t<float, py::array::c_style | py::array::forcecast> arr) {
+                 CloudPtr in = numpyToCloud(arr);
+                 Cloud    ground;
+                 Cloud    nonground;
+                 double   elapsed = 0.0;
+                 self.estimateGround(*in, ground, nonground, elapsed);
+
+                 auto mask = maskByNearest(ground, *in);
+                 return py::make_tuple(mask, elapsed);
+             },
+             "points"_a,
+             "Run TGS on the given points. Returns (ground_mask: bool[N], "
+             "elapsed_seconds: float).");
+
+    // -- ObjectCluster --------------------------------------------------------
+    py::class_<travel::ObjectCluster<PointXYZILID>>(m, "_ObjectCluster")
+        .def(py::init<>())
+        .def("set_params",
+             [](travel::ObjectCluster<PointXYZILID>& self,
+                int   vert_scan,        int   horz_scan,
+                float min_range,        float max_range,
+                float min_vert_angle,   float max_vert_angle,
+                float horz_merge_thres, float vert_merge_thres,
+                int   vert_scan_size,   int   horz_scan_size,
+                int   horz_extension_size, int horz_skip_size,
+                int   downsample,
+                int   min_cluster_size, int max_cluster_size) {
+                 self.setParams(vert_scan, horz_scan,
+                                min_range, max_range,
+                                min_vert_angle, max_vert_angle,
+                                horz_merge_thres, vert_merge_thres,
+                                vert_scan_size, horz_scan_size,
+                                horz_extension_size, horz_skip_size,
+                                downsample,
+                                min_cluster_size, max_cluster_size);
+             },
+             "vert_scan"_a, "horz_scan"_a,
+             "min_range"_a, "max_range"_a,
+             "min_vert_angle"_a, "max_vert_angle"_a,
+             "horz_merge_thres"_a, "vert_merge_thres"_a,
+             "vert_scan_size"_a, "horz_scan_size"_a,
+             "horz_extension_size"_a, "horz_skip_size"_a,
+             "downsample"_a,
+             "min_cluster_size"_a, "max_cluster_size"_a)
+        .def("segment_objects",
+             [](travel::ObjectCluster<PointXYZILID>& self,
+                py::array_t<float, py::array::c_style | py::array::forcecast> arr) {
+                 // Make two copies: the algorithm mutates its input pointer
+                 // (sphericalProjection() reassigns *cloud_in = *valid_cloud),
+                 // so we keep the pristine original around for the
+                 // index-back-mapping nearest-neighbour query.
+                 CloudPtr original = numpyToCloud(arr);
+                 CloudPtr scratch(new Cloud(*original));
+                 CloudPtr out(new Cloud());
+                 self.segmentObjects(scratch, out);
+
+                 return labelByNearest(*out, *original);
+             },
+             "points"_a,
+             "Run AOS clustering on the given points. Returns int32[N] cluster "
+             "labels (0 = unlabeled / outside any cluster, 1..K = cluster id).");
+}


### PR DESCRIPTION
## Summary

Phase 2 of the TRAVEL modernization. Stacks on top of #20 (cpp/ ↔ ros/ split). Adds a `python/` directory that ships a pip-installable, numpy-friendly Python wrapper around the C++ core.

```
pip install -e python/   # from a clone
# or, after publication:
pip install travel-seg
```

```python
import numpy as np
import travel_seg as ts

points = np.fromfile("0000.bin", dtype=np.float32).reshape(-1, 4)
result = ts.segment(points)
ground_pts    = points[result.ground_mask]
cluster_ids   = np.unique(result.instance_labels[result.instance_labels > 0])
```

## What's in the box

| Symbol | Purpose |
|---|---|
| `GroundSegConfig` / `ObjectClusterConfig`     | dataclasses with KITTI-tuned defaults matching `ros/config/`. |
| `TravelGroundSeg(cfg)` / `ObjectCluster(cfg)` | reusable per-frame segmenters. |
| `segment(points, ...)`                        | one-shot helper. |
| `SegmentResult`                               | dataclass: `ground_mask: bool[N]`, `instance_labels: int32[N]`, `elapsed_seconds: float`. |

Inputs accept `(N, 3)` XYZ or `(N, 4)` XYZI float32 arrays. Outputs are aligned with the original input order via a kd-tree nearest-neighbour reverse mapping that reuses the nanoflann helper already vendored in the C++ core (epsilon^2 = 1e-5, same threshold as `travel::saveLabels`).

## Build & packaging plumbing

- `python/pyproject.toml` declares `scikit_build_core` + `pybind11` as build deps.
  - Pinned `cmake.version = ">=3.18,<4"` so Ubuntu 20.04 (system CMake 3.16) gets a newer cmake from the PyPI wheel, and CMake 4.x's hard-error on `cmake_minimum_required(<3.5)` in transitive deps is sidestepped.
- `python/CMakeLists.txt` is dual-mode:
  - In-tree (`pip install -e python/`): `add_subdirectory(../cpp/travel)`.
  - Out-of-tree (PyPI sdist install with no sibling `cpp/`): `FetchContent_Declare(... SOURCE_SUBDIR cpp/travel)` against the GitHub repo.
- The compiled module is named `_travel_seg` and installed inside the package directory, so the public Python surface in `__init__.py` is the only thing users import.

## API choices

- **Class-based + convenience function.** Class instances reuse internal state across frames; the convenience `segment(...)` helper builds both segmenters fresh each call (handy for one-off frames, less so for streaming).
- **Cluster id determinism.** AOS's `labelPointcloud` shuffles cluster ids with `std::random_device` per call, so id values are not stable across calls. The package documents this and the smoke tests verify *structural* equivalence (same partition) rather than bit-equality.
- **Intensity column.** Accepted for convenience when reading raw KITTI .bin files but not consumed by either TGS or AOS — XYZ-only input behaves identically.

## Verification

| Scenario | Environment | Result |
|---|---|---|
| `pip install -e python/` + smoke import | macOS arm64 + Apple Silicon Homebrew clang + PCL 1.15 + Python 3.12 | ✅ |
| `pytest python/tests/` | as above | ✅ 7/7 passed |
| `cmake -S cpp/travel ...` | Ubuntu 20.04 + GCC 9.4 + PCL 1.10 (linux/arm64 docker) | ✅ already verified in #20 |

Linux pip-install path is *not yet* end-to-end verified in CI — Apple Silicon's macOS Docker Desktop bind-mount currently presents stale views of newly written files inside the repo, which made automated `pip install -e python/` runs in a fresh Ubuntu 20.04 container unreliable. Since the C++ core is already proven on Linux and the pip layer is glue (scikit-build-core ⟶ cmake), the residual risk is low; final Linux verification is left to a real Ubuntu host.

## Test plan

- [ ] `pip install -e python/` on a real Ubuntu 20.04 / 22.04 host; run `pytest python/tests/`.
- [ ] `python python/examples/run_kitti.py /path/to/kitti/sequences/00 0` — compare output PCDs / label arrays against `cpp/examples/run_travel_kitti` from #20.
- [ ] (Optional) `pip install build && python -m build python/` to produce an sdist + wheel; install the wheel into a fresh venv to exercise the FetchContent fallback path.

## Notes for reviewers

- This PR depends on #20 ("Split TRAVEL into pure C++ core and ROS1 wrapper"). Land #20 first, then rebase this onto `main` or merge it into the same release.
- Default configs in `_config.py` mirror `ros/config/kitti_params.yaml`. If we want different defaults for the Python entry point (e.g. shorter range for indoor sensors), happy to adjust in a follow-up.