### PR TITLE
release: travel-seg 1.0.0 + GitHub Actions PyPI workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,91 @@
+name: Release (TestPyPI / PyPI)
+
+# Triggered manually from the GitHub Actions UI. Builds the sdist + a Linux
+# wheel, runs twine check, and uploads to either TestPyPI or PyPI based on
+# the `target` input. This keeps the maintainer in the loop — there is no
+# auto-publish on tag push.
+#
+# Required secrets (set under Repo Settings -> Secrets and variables -> Actions):
+#   TEST_PYPI_API_TOKEN  -- token from https://test.pypi.org/manage/account/token/
+#   PYPI_API_TOKEN       -- token from https://pypi.org/manage/account/token/
+#
+# Recommended manual run sequence:
+#   1) Bump version in python/pyproject.toml (and travel_seg/__init__.py
+#      and travel_seg/pybind/travel_pybind.cpp).
+#   2) Tag and push: git tag v1.x.y && git push --tags
+#   3) Run this workflow with target=testpypi.
+#   4) pip install --index-url https://test.pypi.org/simple/ \
+#                  --extra-index-url https://pypi.org/simple/ travel-seg
+#      ... and verify it imports + runs.
+#   5) Re-run with target=pypi.
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Where to upload"
+        required: true
+        type: choice
+        default: testpypi
+        options:
+          - testpypi
+          - pypi
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install C++ build deps
+        # Required because `python -m build` invokes scikit-build-core which
+        # then runs cmake which needs PCL/Boost/MPI to compile the pybind
+        # extension into the wheel.
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            build-essential cmake \
+            libeigen3-dev \
+            libboost-system-dev libboost-filesystem-dev \
+            libpcl-dev mpi-default-dev
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install build + twine
+        run: python -m pip install --upgrade pip build twine
+
+      - name: Build sdist + wheel
+        run: |
+          rm -rf dist/
+          python -m build python/ --outdir dist/
+          ls -la dist/
+
+      - name: twine check
+        run: twine check dist/*
+
+      - name: Upload to TestPyPI
+        if: ${{ inputs.target == 'testpypi' }}
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        run: twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+
+      - name: Upload to PyPI
+        if: ${{ inputs.target == 'pypi' }}
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: twine upload dist/*
+
+      - name: Upload artefacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ inputs.target }}
+          path: dist/
+          retention-days: 30

--- a/python/README.md
+++ b/python/README.md
@@ -19,13 +19,13 @@ cd TRAVEL
 pip install -e python/
 ```
 
-### From PyPI (planned)
+### From PyPI
 
 ```bash
 pip install travel-seg
 ```
 
-The PyPI sdist's `python/CMakeLists.txt` falls back to `FetchContent` for the C++ core, so no separate clone is needed.
+The PyPI sdist's `python/CMakeLists.txt` falls back to `FetchContent` for the C++ core, so no separate clone is needed. System-side, you still need PCL + Boost + Eigen on the build path — see the system-deps lines in the source-install block above.
 
 ## Usage
 
@@ -84,3 +84,33 @@ python python/examples/run_kitti.py /path/to/kitti/sequences/00 0 /tmp/out
 ## Citation
 
 See the top-level [README](../README.md).
+
+## Release process
+
+Releases are cut manually via the GitHub Actions `Release (TestPyPI / PyPI)`
+workflow. To publish a new version:
+
+1. Bump version in three places to keep them in sync:
+   - `python/pyproject.toml` -> `[project] version`
+   - `python/travel_seg/__init__.py` -> `__version__`
+   - `python/travel_seg/pybind/travel_pybind.cpp` -> `m.attr("__version__")`
+2. Commit, tag, push:
+   ```bash
+   git commit -am "release: travel-seg vX.Y.Z"
+   git tag vX.Y.Z
+   git push origin main vX.Y.Z
+   ```
+3. Trigger the workflow with `target=testpypi` from the GitHub Actions UI.
+4. Verify the install:
+   ```bash
+   python -m venv /tmp/check && source /tmp/check/bin/activate
+   pip install --index-url https://test.pypi.org/simple/ \
+               --extra-index-url https://pypi.org/simple/ travel-seg==X.Y.Z
+   python -c "import travel_seg as ts; import numpy as np; \
+              ts.segment(np.random.uniform(-10,10,(2000,3)).astype(np.float32))"
+   ```
+5. Re-run the workflow with `target=pypi` to push to the real index.
+
+Required repo secrets (Settings -> Secrets and variables -> Actions):
+- `TEST_PYPI_API_TOKEN` from https://test.pypi.org/manage/account/token/
+- `PYPI_API_TOKEN` from https://pypi.org/manage/account/token/

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "travel-seg"
-version = "0.1.0"
+version = "1.0.0"
 requires-python = ">=3.8"
 description = "Python bindings for TRAVEL: traversable ground and above-ground object segmentation for 3D LiDAR scans"
 readme = "README.md"

--- a/python/travel_seg/__init__.py
+++ b/python/travel_seg/__init__.py
@@ -19,7 +19,7 @@ Quick start::
 from ._api import ObjectCluster, TravelGroundSeg, segment
 from ._config import GroundSegConfig, ObjectClusterConfig, SegmentResult
 
-__version__ = "0.1.0"
+__version__ = "1.0.0"
 
 __all__ = [
     "GroundSegConfig",

--- a/python/travel_seg/pybind/travel_pybind.cpp
+++ b/python/travel_seg/pybind/travel_pybind.cpp
@@ -151,7 +151,7 @@ PYBIND11_MODULE(_travel_seg, m) {
     m.doc() =
         "pybind11 bindings for the TRAVEL traversable-ground / object "
         "segmentation library.";
-    m.attr("__version__") = "0.1.0";
+    m.attr("__version__") = "1.0.0";
 
     // -- TravelGroundSeg ------------------------------------------------------
     py::class_<travel::TravelGroundSeg<PointXYZILID>>(m, "_TravelGroundSeg")


### PR DESCRIPTION
Sets up the publishing path so the next step is just adding two secrets and pressing **Run workflow**.

## Changes

- Bump travel-seg version to **1.0.0** in pyproject.toml, `travel_seg/__init__.py`, and the pybind `__version__` attribute, aligning the Python wheel with travel_ros 1.0.0 (ROS 2 era).
- New `.github/workflows/release.yml` — manually triggered (`workflow_dispatch`) build + upload pipeline. Runs `python -m build python/`, twine check, then either `twine upload --repository-url https://test.pypi.org/legacy/ ...` or the real index, gated by a `target` choice input.
- `python/README.md` documents the bump → tag → TestPyPI → PyPI sequence so future releases follow the same path.

## Local verification

```bash
$ python -m build python/ --outdir /tmp/dist/
Successfully built travel_seg-1.0.0.tar.gz and travel_seg-1.0.0-cp312-cp312-macosx_26_0_arm64.whl
$ twine check /tmp/dist/*
PASSED on both
$ python -m venv /tmp/v && /tmp/v/bin/pip install /tmp/dist/travel_seg-1.0.0.tar.gz
# scikit-build-core configures CMake; CMakeLists falls into the FetchContent
# branch (no sibling cpp/) and clones url-kaist/TRAVEL@main to grab cpp/travel/.
Successfully installed travel-seg-1.0.0
$ /tmp/v/bin/python -c "import travel_seg as ts, numpy as np; ts.segment(...)"
travel_seg 1.0.0 / OK ground=4960
```

So `pip install travel-seg` is going to work end-to-end once we upload.

## What you need to do after this PR merges

1. **Generate API tokens.**
   - https://test.pypi.org/manage/account/token/  →  `TEST_PYPI_API_TOKEN`
   - https://pypi.org/manage/account/token/       →  `PYPI_API_TOKEN`
2. **Add them as repo secrets** at Settings → Secrets and variables → Actions.
3. **Tag.** `git tag v1.0.0 && git push origin v1.0.0` (the ROS 1 era v0.1 tag stays untouched).
4. **Run the workflow** with `target=testpypi`. Verify a clean install:
   ```bash
   pip install --index-url https://test.pypi.org/simple/ \
               --extra-index-url https://pypi.org/simple/ travel-seg==1.0.0
   ```
5. **Re-run** with `target=pypi`.

## Notes

- The `pypi.org/pypi/travel/` slot is taken by an unrelated package, which is why we use `travel-seg`. `import travel_seg as ts` matches what we put in the README.
- Wheels published from this workflow are Linux x86_64 only. macOS / Windows users (and Linux aarch64 users on non-glibc distros) will get the sdist and re-compile against their local PCL/Boost/Eigen. Adding cibuildwheel is a follow-up if we want broader prebuilt coverage.
- The release workflow does *not* trigger on git tag push — it's manual on purpose so accidentally pushing a tag doesn't burn a PyPI version slot.

## Test plan

- [ ] CI green on this PR.
- [ ] Add the two secrets, tag v1.0.0, run the workflow with target=testpypi; install succeeds in a fresh venv.
- [ ] Re-run with target=pypi; `pip install travel-seg` works on a stranger's machine.