### PR TITLE
chore(release): switch PyPI upload to Trusted Publisher (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,41 +1,35 @@
-name: Release (TestPyPI / PyPI)
+name: Release (PyPI)
 
 # Triggered manually from the GitHub Actions UI. Builds the sdist + a Linux
-# wheel, runs twine check, and uploads to either TestPyPI or PyPI based on
-# the `target` input. This keeps the maintainer in the loop — there is no
-# auto-publish on tag push.
+# wheel, runs twine check, and uploads to PyPI via Trusted Publishing
+# (OIDC) — no API token / GitHub secret required.
 #
-# Required secrets (set under Repo Settings -> Secrets and variables -> Actions):
-#   TEST_PYPI_API_TOKEN  -- token from https://test.pypi.org/manage/account/token/
-#   PYPI_API_TOKEN       -- token from https://pypi.org/manage/account/token/
+# One-time PyPI setup (https://pypi.org/manage/account/publishing/):
+#   Add a "pending publisher" with the following settings before the very
+#   first release. After the first publish, this becomes a regular
+#   "Trusted Publisher" attached to the project.
+#
+#       PyPI Project Name: travel-seg
+#       Owner            : url-kaist
+#       Repository name  : TRAVEL
+#       Workflow name    : release.yml
+#       Environment name : pypi
 #
 # Recommended manual run sequence:
-#   1) Bump version in python/pyproject.toml (and travel_seg/__init__.py
-#      and travel_seg/pybind/travel_pybind.cpp).
-#   2) Tag and push: git tag v1.x.y && git push --tags
-#   3) Run this workflow with target=testpypi.
-#   4) pip install --index-url https://test.pypi.org/simple/ \
-#                  --extra-index-url https://pypi.org/simple/ travel-seg
-#      ... and verify it imports + runs.
-#   5) Re-run with target=pypi.
+#   1) Bump version in python/pyproject.toml, travel_seg/__init__.py,
+#      and travel_seg/pybind/travel_pybind.cpp.
+#   2) Tag and push: git tag vX.Y.Z && git push origin vX.Y.Z
+#   3) Run this workflow from the Actions tab.
+#   4) Verify install in a fresh venv:
+#        pip install travel-seg==X.Y.Z
 
 on:
   workflow_dispatch:
-    inputs:
-      target:
-        description: "Where to upload"
-        required: true
-        type: choice
-        default: testpypi
-        options:
-          - testpypi
-          - pypi
 
 jobs:
-  build-and-upload:
+  build:
+    name: Build sdist + wheel
     runs-on: ubuntu-22.04
-    permissions:
-      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -69,23 +63,31 @@ jobs:
       - name: twine check
         run: twine check dist/*
 
-      - name: Upload to TestPyPI
-        if: ${{ inputs.target == 'testpypi' }}
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        run: twine upload --repository-url https://test.pypi.org/legacy/ dist/*
-
-      - name: Upload to PyPI
-        if: ${{ inputs.target == 'pypi' }}
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: twine upload dist/*
-
-      - name: Upload artefacts
+      - name: Upload distributions as workflow artefact
         uses: actions/upload-artifact@v4
         with:
-          name: dist-${{ inputs.target }}
+          name: dist
           path: dist/
           retention-days: 30
+
+  publish-pypi:
+    name: Publish to PyPI (Trusted Publisher)
+    needs: build
+    runs-on: ubuntu-22.04
+    # The `environment` and `permissions: id-token: write` blocks together
+    # are what activate Trusted Publishing — pypi.org verifies the OIDC
+    # token from this exact (repo, workflow, environment) tuple.
+    environment:
+      name: pypi
+      url: https://pypi.org/p/travel-seg
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/python/README.md
+++ b/python/README.md
@@ -87,8 +87,28 @@ See the top-level [README](../README.md).
 
 ## Release process
 
-Releases are cut manually via the GitHub Actions `Release (TestPyPI / PyPI)`
-workflow. To publish a new version:
+Publishing uses **PyPI Trusted Publishing (OIDC)**, so there are no API
+tokens or GitHub secrets to manage. PyPI authenticates the GitHub Actions
+workflow directly based on a one-time pending-publisher registration.
+
+### One-time PyPI setup
+
+Visit https://pypi.org/manage/account/publishing/ and add a *pending*
+publisher with these values (only required before the very first release;
+it auto-graduates to a regular trusted publisher after the first upload):
+
+| Field | Value |
+|---|---|
+| PyPI Project Name | `travel-seg` |
+| Owner | `url-kaist` |
+| Repository name | `TRAVEL` |
+| Workflow name | `release.yml` |
+| Environment name | `pypi` |
+
+GitHub side: create an environment named `pypi` at Settings -> Environments
+(no secrets/protection rules needed unless you want manual approval).
+
+### Per-release flow
 
 1. Bump version in three places to keep them in sync:
    - `python/pyproject.toml` -> `[project] version`
@@ -100,17 +120,11 @@ workflow. To publish a new version:
    git tag vX.Y.Z
    git push origin main vX.Y.Z
    ```
-3. Trigger the workflow with `target=testpypi` from the GitHub Actions UI.
-4. Verify the install:
+3. Trigger the **Release (PyPI)** workflow from the GitHub Actions UI.
+4. Verify the install in a fresh venv:
    ```bash
    python -m venv /tmp/check && source /tmp/check/bin/activate
-   pip install --index-url https://test.pypi.org/simple/ \
-               --extra-index-url https://pypi.org/simple/ travel-seg==X.Y.Z
+   pip install travel-seg==X.Y.Z
    python -c "import travel_seg as ts; import numpy as np; \
               ts.segment(np.random.uniform(-10,10,(2000,3)).astype(np.float32))"
    ```
-5. Re-run the workflow with `target=pypi` to push to the real index.
-
-Required repo secrets (Settings -> Secrets and variables -> Actions):
-- `TEST_PYPI_API_TOKEN` from https://test.pypi.org/manage/account/token/
-- `PYPI_API_TOKEN` from https://pypi.org/manage/account/token/


### PR DESCRIPTION
Replace the API-token-based release workflow from #25 with PyPI's Trusted Publisher (OIDC) flow. Same pattern as KISS-Matcher and most modern PyPI projects.

## Why

- **No secrets to manage.** The workflow exchanges a short-lived GitHub Actions OIDC token for the publish right. There is no `PYPI_API_TOKEN` to rotate, store, or worry about leaking via a misconfigured log.
- **Tightly scoped.** Only this exact `release.yml` file in `url-kaist/TRAVEL`, running under the `pypi` environment, can publish. A fork running the same workflow can't authenticate.
- **Standard.** PyPI itself recommends this over tokens; `pypa/gh-action-pypi-publish` is a one-line action.

## Changes

`.github/workflows/release.yml`:
- Drops the `target: testpypi | pypi` choice — TestPyPI was unused; we go straight to PyPI now per [user discussion]. Easy to re-add later if we want sandbox uploads.
- Splits into two jobs:
  - `build` — builds sdist + wheel, runs twine check, uploads `dist/` as a workflow artifact for inspection.
  - `publish-pypi` — gated by `environment: pypi` and `permissions: id-token: write`, then uses `pypa/gh-action-pypi-publish@release/v1` to upload. These two blocks together activate Trusted Publishing on PyPI's side.

`python/README.md` is updated with the new flow.

## Maintainer setup (one time, before the first release)

**On PyPI** (https://pypi.org/manage/account/publishing/, "Add a pending publisher"):

| Field | Value |
|---|---|
| PyPI Project Name | `travel-seg` |
| Owner | `url-kaist` |
| Repository name | `TRAVEL` |
| Workflow name | `release.yml` |
| Environment name | `pypi` |

**On GitHub** (Settings → Environments):
- Create a new environment named `pypi`. No protection rules required (optional: add manual approval if you want a second eyes click before publish).

After those two are in place, every release is just:

```bash
# bump version in pyproject.toml + __init__.py + travel_pybind.cpp
git commit -am "release: travel-seg vX.Y.Z"
git tag vX.Y.Z
git push origin main vX.Y.Z
# then trigger the workflow from the Actions UI
```

## Test plan

- [ ] Merge.
- [ ] Maintainer creates the pending publisher on PyPI + the `pypi` environment on GitHub.
- [ ] Tag `v1.0.0`, run the workflow, watch the publish job auth via OIDC, and `pip install travel-seg==1.0.0` from a fresh venv.