### PR TITLE
fix: zero-init TGS empty_trigrid_node_ + AOS Point/AOSNode (root-cause CI flakes)

### DIFF
--- a/cpp/travel/core/travel/aos.hpp
+++ b/cpp/travel/core/travel/aos.hpp
@@ -26,19 +26,25 @@ namespace travel {
 
     class AOSNode {
         public:
-            uint start;
-            uint end;
-            int label;
+            // start/end were declared without in-class initializers; combined
+            // with the uninit `int label` in `Point`, this leaked stack
+            // garbage into the per-channel node lists in horizontalUpdate
+            // and made cluster filtering decisions in labelPointcloud
+            // run-to-run nondeterministic. Zero-init makes the algorithm
+            // produce the same partition every time the input is the same.
+            uint start = 0;
+            uint end   = 0;
+            int  label;
 
-            AOSNode() : label(-1) {} 
+            AOSNode() : label(-1) {}
     };
 
     class Point {
         public:
-            float x,y,z;
-            uint idx;
+            float x{0.0f}, y{0.0f}, z{0.0f};
+            uint idx{0};
             bool valid = false;
-            int label;
+            int  label{0};
     };
 
     template <typename T>

--- a/cpp/travel/core/travel/tgs.hpp
+++ b/cpp/travel/core/travel/tgs.hpp
@@ -358,13 +358,22 @@ namespace travel {
             empty_trigrid_node_.check_life = 10;
             empty_trigrid_node_.depth = -1;
 
-            empty_trigrid_node_.normal;
-            empty_trigrid_node_.mean_pt;
-            empty_trigrid_node_.d = 0;
-            
-            empty_trigrid_node_.singular_values;
-            empty_trigrid_node_.eigen_vectors;
-            empty_trigrid_node_.weight = 0;
+            // The four lines below were no-op expression statements — almost
+            // certainly intended as zero-initializations but missing the
+            // assignment. Eigen types do not zero-init by default for
+            // performance, so without these the empty_trigrid_node_ ships
+            // four uninitialized members; copies of it then seed every
+            // node in trigrid_field_ with stack garbage. The algorithm
+            // overwrites these in the common path, but a few edge cases
+            // (small empty cells, boundary nodes) end up reading them,
+            // which surfaces as run-to-run nondeterminism downstream.
+            empty_trigrid_node_.normal          = Eigen::Vector3f::Zero();
+            empty_trigrid_node_.mean_pt         = Eigen::Vector3f::Zero();
+            empty_trigrid_node_.d               = 0;
+
+            empty_trigrid_node_.singular_values = Eigen::Vector3f::Zero();
+            empty_trigrid_node_.eigen_vectors   = Eigen::Matrix3f::Zero();
+            empty_trigrid_node_.weight          = 0;
 
             empty_trigrid_node_.th_dist_d = 0;
             empty_trigrid_node_.th_outlier_d = 0;


### PR DESCRIPTION
Two related uninit-memory bugs that caused 1-1.5% run-to-run mismatches in the Python smoke tests on the GitHub Ubuntu runners. Same shape in both: a class member declared without an initializer, copied into a working buffer that the algorithm then assumes is zeroed.

## TGS

`initTriGridField` had four no-op expression statements where it clearly intended to zero-initialize the Eigen members of `empty_trigrid_node_`:

```cpp
empty_trigrid_node_.normal;            // evaluates, drops the lvalue
empty_trigrid_node_.mean_pt;           // same
empty_trigrid_node_.singular_values;   // same
empty_trigrid_node_.eigen_vectors;     // same
```

Eigen vectors/matrices don't zero-init by default. `empty_trigrid_node_` then got copied into every cell of `trigrid_field_`, seeding the whole field with stack garbage.

Fix: replace with explicit `Eigen::Vector3f::Zero()` / `Eigen::Matrix3f::Zero()`.

## AOS

`class Point` declared `int label;` (and `float x,y,z;`, `uint idx;`) without in-class initializers. `range_mat_` entries got assigned fresh `Point` copies in `sphericalProjection`, leaking the uninit `label` field into the working set. `class AOSNode` had the same problem on its `start` / `end` members. Combined, they made cluster filtering decisions in `labelPointcloud` run-to-run nondeterministic — about 1-1.5% of points flipped between "in some cluster" and "no cluster" on consecutive `segment_objects` calls with identical input.

Fix: brace-init (`label{0}`, `start = 0`, etc.).

## Why this is safe under the "never break the pipeline" rule

This is a *correctness* fix, not a behavior change. The existing code's output was already nondeterministic, so there's no single "original behavior" to preserve. What we want to preserve is the deterministic majority result, which is exactly what the algorithm produces in the common (non-uninit-read) path.

Verified on macOS arm64:

```
$ ./build/tests/regression_kitti kitti00_000000.bin /tmp/run.bin cpp/tests/data/kitti00_000000_gold.bin
REGRESSION PASS: bit-identical to cpp/tests/data/kitti00_000000_gold.bin (374008 bytes)
```

So the algorithm's output on KITTI sequence 00 frame 0 (with AOS seed=42) is byte-for-byte the same as the gold dump captured pre-fix. The fix moves the previously-stochastic minority into the same canonical answer the deterministic majority was already producing.

`test_xyz_and_xyzi_inputs_both_accepted` and `test_class_api_matches_convenience_function` ran 30 times back-to-back on macOS — 30/30 passed for both (each was flaking ~1-1.5% on the Ubuntu runner before this commit).

Full `pytest python/tests/` -> 7/7 passed.

## Test plan

- [ ] CI green across all 6 jobs (KITTI bit-compare in particular).
- [ ] Two CI runs back-to-back (workflow re-run from this PR's HEAD) both green — confirms the AOS-side flake is gone, not just rerun-lucky.