### PR TITLE
feat(core): drop PCL + Boost; release travel-seg 1.1.0 with cibuildwheel (Linux + macOS + Windows)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,17 +108,19 @@ jobs:
 
       - name: Smoke-run run_travel_kitti
         # Exit non-zero if the binary crashes, OR if any of the three
-        # expected PCDs are missing or empty. We don't bit-compare the PCD
-        # contents — that's covered by the C++ regression job. This is just
-        # "did the standalone path break?".
+        # expected output bins are missing or empty. We don't bit-compare
+        # the contents — that's covered by the C++ regression job. This is
+        # just "did the standalone path break?". Output format flipped
+        # from .pcd to plain Nx4 / Nx5 float32 .bin in v1.1 when PCL was
+        # dropped from the core.
         run: |
           mkdir -p /tmp/example_out
           ./build/examples/run_travel_kitti /tmp/kitti_seq/00 0 /tmp/example_out
           ls -la /tmp/example_out/
-          for f in /tmp/example_out/0_ground.pcd /tmp/example_out/0_nonground.pcd /tmp/example_out/0_labeled.pcd; do
+          for f in /tmp/example_out/0_ground.bin /tmp/example_out/0_nonground.bin /tmp/example_out/0_labeled.bin; do
             test -s "$f" || { echo "missing or empty: $f"; exit 1; }
           done
-          echo "PCD outputs look healthy."
+          echo "Outputs look healthy."
 
       - name: Upload example output on failure
         if: failure()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,19 +82,19 @@ jobs:
         uses: pypa/cibuildwheel@v2.21.3
         env:
           # PyPy lacks the C API symbols pybind11 needs (PyModule_GetFilenameObject etc.).
-          # Restrict to CPython only — PyPy native-extension support is not a goal here.
-          CIBW_SKIP: "pp* *-musllinux_*"
+          # Restrict to CPython only — PyPy native-extension support is not a goal.
+          # Also skip 32-bit Linux (i686) and musllinux to keep the matrix small;
+          # users on those platforms can still install from sdist.
+          CIBW_SKIP: "pp* *-manylinux_i686 *-musllinux_* *-win32"
           # macOS: build both arm64 and x86_64 from the macos-14 (arm64) runner.
-          CIBW_ARCHS_MACOS: "arm64 x86_64"
-          # The cibuildwheel-default manylinux2014 image already ships GCC + Eigen
-          # via dnf? No — Eigen is not in the default image. We install it before
-          # each per-tag build. Same on macOS / Windows.
-          CIBW_BEFORE_ALL_LINUX: "yum install -y eigen3-devel"
-          CIBW_BEFORE_ALL_MACOS: "brew install eigen"
-          CIBW_BEFORE_ALL_WINDOWS: "vcpkg install eigen3:x64-windows"
-          # Tell cmake (via scikit-build-core) where vcpkg's Eigen lives.
-          CIBW_ENVIRONMENT_WINDOWS: 'CMAKE_PREFIX_PATH="C:/vcpkg/installed/x64-windows"'
-          # cibuildwheel runs `pip install` from this directory.
+          # 10.13 is the floor for std::thread / std::shared_ptr in libc++ on
+          # x86_64 — the default cp38 deployment target (10.9) is too old.
+          CIBW_ARCHS_MACOS:        "arm64 x86_64"
+          CIBW_ENVIRONMENT_MACOS:  "MACOSX_DEPLOYMENT_TARGET=10.13"
+          # Eigen is the only system dep. cpp/travel/CMakeLists.txt now
+          # FetchContent-fallback when the system Eigen isn't found, so we
+          # don't need CIBW_BEFORE_ALL_* to apt/brew/vcpkg-install it on the
+          # build container. The fetch is ~10MB and only fires when needed.
         with:
           package-dir: python/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,45 +1,39 @@
 name: Release (PyPI)
 
-# Triggered manually from the GitHub Actions UI. Builds the sdist + a Linux
-# wheel, runs twine check, and uploads to PyPI via Trusted Publishing
-# (OIDC) — no API token / GitHub secret required.
+# Builds the sdist and a per-platform wheel matrix (Linux x86_64 manylinux,
+# macOS arm64 + x86_64, Windows x86_64), then publishes to PyPI via Trusted
+# Publishing (OIDC). No API token / GitHub secret required.
+#
+# travel-seg's pybind extension only depends on Eigen since v1.1 (PCL was
+# dropped from the core), so cibuildwheel can produce wheels for every
+# target platform without bringing in a vcpkg / brew / apt PCL install.
 #
 # One-time PyPI setup (https://pypi.org/manage/account/publishing/):
-#   Add a "pending publisher" with the following settings before the very
-#   first release. After the first publish, this becomes a regular
-#   "Trusted Publisher" attached to the project.
-#
+#   "Add a pending publisher" with:
 #       PyPI Project Name: travel-seg
 #       Owner            : url-kaist
 #       Repository name  : TRAVEL
 #       Workflow name    : release.yml
 #       Environment name : pypi
 #
-# Recommended manual run sequence:
+# Per-release flow:
 #   1) Bump version in python/pyproject.toml, travel_seg/__init__.py,
-#      and travel_seg/pybind/travel_pybind.cpp.
-#   2) Tag and push: git tag vX.Y.Z && git push origin vX.Y.Z
-#   3) Run this workflow from the Actions tab.
-#   4) Verify install in a fresh venv:
-#        pip install travel-seg==X.Y.Z
+#      travel_seg/pybind/travel_pybind.cpp.
+#   2) git tag vX.Y.Z && git push origin vX.Y.Z
+#   3) Run this workflow from the Actions tab. It tests on PR / push too,
+#      but only uploads to PyPI when the run is from a tag (GitHub Release).
 
 on:
   workflow_dispatch:
+  push:
+    tags: ['v*']
+  pull_request:
+    branches: [main]
 
 jobs:
-  build:
+  sdist:
     name: Build sdist
     runs-on: ubuntu-22.04
-    # We deliberately publish *only* an sdist (no wheel). Reasons:
-    # * PyPI rejects vanilla `linux_x86_64` wheels — only `manylinux_*`
-    #   tags are accepted, which would mean cibuildwheel inside a manylinux
-    #   container.
-    # * travel_seg's pybind extension links against system PCL / Boost /
-    #   Eigen. Shipping a prebuilt wheel risks ABI mismatch with the user's
-    #   PCL on Ubuntu 22.04 vs 24.04 vs macOS Homebrew. `pip install` from
-    #   sdist re-compiles against the local PCL, which is what we want.
-    # The C++ deps are therefore not installed in this job — sdist creation
-    # only packages source files and does not invoke cmake.
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -61,31 +55,78 @@ jobs:
       - name: twine check
         run: twine check dist/*
 
-      - name: Upload distributions as workflow artefact
+      - name: Upload sdist artefact
         uses: actions/upload-artifact@v4
         with:
-          name: dist
-          path: dist/
+          name: dist-sdist
+          path: dist/*.tar.gz
+          retention-days: 30
+
+  wheels:
+    name: Build wheels (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # ubuntu-22.04 produces manylinux_2_17_x86_64 wheels via cibuildwheel
+        # (which runs the build in a manylinux container, not on the host).
+        # macos-14 = Apple Silicon (arm64) runner — also builds an x86_64
+        # wheel via cross-compile when CIBW_ARCHS_MACOS includes it.
+        # windows-2022 produces win_amd64.
+        os: [ubuntu-22.04, macos-14, windows-2022]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.21.3
+        env:
+          # PyPy lacks the C API symbols pybind11 needs (PyModule_GetFilenameObject etc.).
+          # Restrict to CPython only — PyPy native-extension support is not a goal here.
+          CIBW_SKIP: "pp* *-musllinux_*"
+          # macOS: build both arm64 and x86_64 from the macos-14 (arm64) runner.
+          CIBW_ARCHS_MACOS: "arm64 x86_64"
+          # The cibuildwheel-default manylinux2014 image already ships GCC + Eigen
+          # via dnf? No — Eigen is not in the default image. We install it before
+          # each per-tag build. Same on macOS / Windows.
+          CIBW_BEFORE_ALL_LINUX: "yum install -y eigen3-devel"
+          CIBW_BEFORE_ALL_MACOS: "brew install eigen"
+          CIBW_BEFORE_ALL_WINDOWS: "vcpkg install eigen3:x64-windows"
+          # Tell cmake (via scikit-build-core) where vcpkg's Eigen lives.
+          CIBW_ENVIRONMENT_WINDOWS: 'CMAKE_PREFIX_PATH="C:/vcpkg/installed/x64-windows"'
+          # cibuildwheel runs `pip install` from this directory.
+        with:
+          package-dir: python/
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-wheels-${{ matrix.os }}
+          path: ./wheelhouse/*.whl
           retention-days: 30
 
   publish-pypi:
     name: Publish to PyPI (Trusted Publisher)
-    needs: build
+    needs: [sdist, wheels]
+    # Only upload to PyPI when this run is from a tag push (GitHub release).
+    # Workflow-dispatch / PR runs build artefacts but stop short of upload.
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-22.04
-    # The `environment` and `permissions: id-token: write` blocks together
-    # are what activate Trusted Publishing — pypi.org verifies the OIDC
-    # token from this exact (repo, workflow, environment) tuple.
     environment:
       name: pypi
       url: https://pypi.org/p/travel-seg
     permissions:
       id-token: write
     steps:
-      - name: Download distributions
+      - name: Download all distributions
         uses: actions/download-artifact@v4
         with:
-          name: dist
-          path: dist/
+          path: dist
+          pattern: dist-*
+          merge-multiple: true
+
+      - name: Show what we're about to upload
+        run: ls -la dist/
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -44,8 +44,17 @@ TRAVEL/
 ### Python (pip)
 
 ```
-# Ubuntu deps:  sudo apt install build-essential cmake libeigen3-dev libpcl-dev libboost-system-dev libboost-filesystem-dev
-# macOS deps:   brew install cmake eigen boost pcl
+pip install travel-seg
+```
+
+Prebuilt wheels are published for **Linux x86_64 (manylinux), macOS arm64 + x86_64, and Windows x86_64** for CPython 3.8–3.13 — no system PCL / Boost install required since v1.1.
+
+For development from a checkout:
+
+```
+# Ubuntu deps:  sudo apt install build-essential cmake libeigen3-dev
+# macOS deps:   brew install cmake eigen
+# Windows deps: vcpkg install eigen3:x64-windows
 
 git clone https://github.com/url-kaist/TRAVEL.git
 cd TRAVEL

--- a/cpp/examples/CMakeLists.txt
+++ b/cpp/examples/CMakeLists.txt
@@ -18,18 +18,5 @@ if (NOT TARGET travel::travel_core)
     find_package(travel REQUIRED)
 endif()
 
-# Materialize MPI::MPI_C before PCL on platforms where libpcl-dev is built
-# against VTK 9.1 (Ubuntu 22.04+); see cpp/tests/CMakeLists.txt for
-# context. No-op where PCL's VTK doesn't require MPI.
-find_package(MPI)
-find_package(PCL REQUIRED COMPONENTS common io filters)
-
 add_executable(run_travel_kitti src/run_travel_kitti.cpp)
-target_link_libraries(run_travel_kitti
-    PRIVATE
-        travel::travel_core
-        ${PCL_LIBRARIES}
-)
-target_include_directories(run_travel_kitti SYSTEM PRIVATE
-    ${PCL_INCLUDE_DIRS}
-)
+target_link_libraries(run_travel_kitti PRIVATE travel::travel_core)

--- a/cpp/examples/src/run_travel_kitti.cpp
+++ b/cpp/examples/src/run_travel_kitti.cpp
@@ -1,5 +1,5 @@
 // Standalone KITTI demo for the TRAVEL ground / above-ground object
-// segmentation library. No ROS required.
+// segmentation library. PCL-free; only depends on the travel core (Eigen).
 //
 // Usage:
 //   run_travel_kitti <kitti_seq_dir> [frame_index] [output_dir]
@@ -8,27 +8,48 @@
 //                    (the labels/ subdir is optional; not used here)
 //   [frame_index]    optional, default 0
 //   [output_dir]     optional, if given will write
-//                       <output_dir>/ground_<idx>.pcd
-//                       <output_dir>/nonground_<idx>.pcd
-//                       <output_dir>/labeled_<idx>.pcd
+//                       <output_dir>/<idx>_ground.bin     (Nx4 float32 XYZI)
+//                       <output_dir>/<idx>_nonground.bin  (same)
+//                       <output_dir>/<idx>_labeled.bin    (Nx5 float32 XYZI + cluster_id-as-float)
 //
 // The aim of this example is twofold: (1) prove the C++ core builds and runs
-// without any ROS dependency, and (2) give downstream users a concrete entry
-// point for benchmarking on KITTI.
+// without any ROS or PCL dependency, and (2) give downstream users a concrete
+// entry point for benchmarking on KITTI.
 
-#define PCL_NO_PRECOMPILE
-
+#include <cstdint>
+#include <cstdio>
+#include <fstream>
 #include <iostream>
 #include <string>
-
-#include <pcl/io/pcd_io.h>
-#include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
+#include <vector>
 
 #include "travel/aos.hpp"
 #include "travel/kitti_loader.hpp"
 #include "travel/point_types.hpp"
 #include "travel/tgs.hpp"
+
+namespace {
+
+// Write an Nx4 float32 buffer (XYZI). Same shape as KITTI velodyne .bin so
+// downstream tooling can reuse the existing loaders.
+void writeXYZI(const std::string& path, const travel::PointCloud<PointXYZILID>& cloud) {
+    std::ofstream of(path, std::ios::binary);
+    for (const auto& p : cloud.points) {
+        const float row[4] = {p.x, p.y, p.z, p.intensity};
+        of.write(reinterpret_cast<const char*>(row), sizeof(row));
+    }
+}
+
+// Nx5 float32: XYZI + cluster_id as float for trivial inspection.
+void writeXYZIID(const std::string& path, const travel::PointCloud<PointXYZILID>& cloud) {
+    std::ofstream of(path, std::ios::binary);
+    for (const auto& p : cloud.points) {
+        const float row[5] = {p.x, p.y, p.z, p.intensity, static_cast<float>(p.id)};
+        of.write(reinterpret_cast<const char*>(row), sizeof(row));
+    }
+}
+
+}  // namespace
 
 int main(int argc, char** argv) {
     if (argc < 2) {
@@ -59,43 +80,30 @@ int main(int argc, char** argv) {
     }
 
     // Convert PointXYZI -> PointXYZILID (TRAVEL's working point type).
-    pcl::PointCloud<PointXYZILID>::Ptr cloud_in(new pcl::PointCloud<PointXYZILID>());
+    auto cloud_in = std::make_shared<travel::PointCloud<PointXYZILID>>();
     cloud_in->reserve(xyzi->size());
     for (const auto& p : xyzi->points) {
-        PointXYZILID q;
-        q.x         = p.x;
-        q.y         = p.y;
-        q.z         = p.z;
+        PointXYZILID q{};
+        q.x = p.x; q.y = p.y; q.z = p.z;
         q.intensity = p.intensity;
-        q.label     = 0;
-        q.id        = 0;
+        q.label = 0;
+        q.id    = 0;
         cloud_in->emplace_back(q);
     }
 
     // ----- Ground segmentation (TGS) ---------------------------------------
     travel::TravelGroundSeg<PointXYZILID> tgs;
-    // Defaults roughly mirror config/kitti_params.yaml, but tweak as needed.
     const double max_range = 80.0;
     const double min_range = 1.0;
-    tgs.setParams(/*max_range=*/max_range,
-                  /*min_range=*/min_range,
-                  /*resolution=*/8.0,
-                  /*num_iter=*/3,
-                  /*num_lpr=*/5,
-                  /*num_min_pts=*/10,
-                  /*th_seeds=*/0.5,
-                  /*th_dist=*/0.125,
-                  /*th_outlier=*/0.3,
-                  /*th_normal=*/0.940,
-                  /*th_weight=*/200.0,
-                  /*th_lcc_normal=*/0.03,
-                  /*th_lcc_planar=*/0.1,
-                  /*th_obstacle=*/1.0,
-                  /*refine_mode=*/true,
-                  /*viz_mode=*/false);
+    tgs.setParams(max_range, min_range, /*resolution=*/8.0,
+                  /*num_iter=*/3, /*num_lpr=*/5, /*num_min_pts=*/10,
+                  /*th_seeds=*/0.5, /*th_dist=*/0.125, /*th_outlier=*/0.3,
+                  /*th_normal=*/0.940, /*th_weight=*/200.0,
+                  /*th_lcc_normal=*/0.03, /*th_lcc_planar=*/0.1, /*th_obstacle=*/1.0,
+                  /*refine_mode=*/true, /*viz_mode=*/false);
 
-    pcl::PointCloud<PointXYZILID> ground;
-    pcl::PointCloud<PointXYZILID> nonground;
+    travel::PointCloud<PointXYZILID> ground;
+    travel::PointCloud<PointXYZILID> nonground;
     double tgs_time = 0.0;
     tgs.estimateGround(*cloud_in, ground, nonground, tgs_time);
     std::cout << "[TGS] frame " << frame_idx
@@ -106,41 +114,22 @@ int main(int argc, char** argv) {
 
     // ----- Above-ground object segmentation (AOS) --------------------------
     travel::ObjectCluster<PointXYZILID> aos;
-    aos.setParams(/*vert_scan=*/64,
-                  /*horz_scan=*/4500,
-                  /*min_range=*/static_cast<float>(min_range),
-                  /*max_range=*/static_cast<float>(max_range),
-                  /*min_vert_angle=*/-24.8f,
-                  /*max_vert_angle=*/2.0f,
-                  /*horz_merge_thres=*/0.4f,
-                  /*vert_merge_thres=*/0.5f,
-                  /*vert_scan_size=*/3,
-                  /*horz_scan_size=*/5,
-                  /*horz_extension_size=*/5,
-                  /*horz_skip_size=*/5,
-                  /*downsample=*/1,
-                  /*min_cluster_size=*/10,
-                  /*max_cluster_size=*/30000);
+    aos.setParams(/*vert_scan=*/64, /*horz_scan=*/4500,
+                  static_cast<float>(min_range), static_cast<float>(max_range),
+                  -24.8f, 2.0f, 0.4f, 0.5f, 3, 5, 5, 5, 1, 10, 30000);
 
-    pcl::PointCloud<PointXYZILID>::Ptr nonground_ptr(new pcl::PointCloud<PointXYZILID>(nonground));
-    pcl::PointCloud<PointXYZILID>::Ptr labeled_ptr(new pcl::PointCloud<PointXYZILID>());
+    auto nonground_ptr = std::make_shared<travel::PointCloud<PointXYZILID>>(nonground);
+    auto labeled_ptr   = std::make_shared<travel::PointCloud<PointXYZILID>>();
     aos.segmentObjects(nonground_ptr, labeled_ptr);
     std::cout << "[AOS] labeled points=" << labeled_ptr->size() << std::endl;
 
     // ----- Optional save ---------------------------------------------------
     if (!output_dir.empty()) {
-        pcl::PointCloud<pcl::PointXYZI>::Ptr ground_xyzi(new pcl::PointCloud<pcl::PointXYZI>());
-        pcl::PointCloud<pcl::PointXYZI>::Ptr nonground_xyzi(new pcl::PointCloud<pcl::PointXYZI>());
-        pcl::PointCloud<pcl::PointXYZI>::Ptr labeled_xyzi(new pcl::PointCloud<pcl::PointXYZI>());
-        PointXYZILID2XYZI(ground, ground_xyzi);
-        PointXYZILID2XYZI(nonground, nonground_xyzi);
-        PointXYZILID2XYZI(*labeled_ptr, labeled_xyzi);
-
         const std::string base = output_dir + "/" + std::to_string(frame_idx);
-        pcl::io::savePCDFileBinary(base + "_ground.pcd",    *ground_xyzi);
-        pcl::io::savePCDFileBinary(base + "_nonground.pcd", *nonground_xyzi);
-        pcl::io::savePCDFileBinary(base + "_labeled.pcd",   *labeled_xyzi);
-        std::cout << "Wrote PCDs under " << output_dir << std::endl;
+        writeXYZI(base + "_ground.bin",    ground);
+        writeXYZI(base + "_nonground.bin", nonground);
+        writeXYZIID(base + "_labeled.bin", *labeled_ptr);
+        std::cout << "Wrote " << base << "_{ground,nonground,labeled}.bin" << std::endl;
     }
 
     return 0;

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -18,20 +18,5 @@ if (NOT TARGET travel::travel_core)
     find_package(travel REQUIRED)
 endif()
 
-# On Ubuntu 22.04 + libpcl-dev, PCL pulls in VTK 9.1 whose CMake config
-# advertises VTK::mpi -> MPI::MPI_C. The PCL config doesn't run
-# find_package(MPI), so configure fails unless we materialize MPI::MPI_C
-# ourselves first. The find is tolerant — on platforms without an MPI
-# install (or where VTK doesn't need it), this is a no-op.
-find_package(MPI)
-find_package(PCL REQUIRED COMPONENTS common io filters)
-
 add_executable(regression_kitti regression_kitti.cpp)
-target_link_libraries(regression_kitti
-    PRIVATE
-        travel::travel_core
-        ${PCL_LIBRARIES}
-)
-target_include_directories(regression_kitti SYSTEM PRIVATE
-    ${PCL_INCLUDE_DIRS}
-)
+target_link_libraries(regression_kitti PRIVATE travel::travel_core)

--- a/cpp/tests/regression_kitti.cpp
+++ b/cpp/tests/regression_kitti.cpp
@@ -49,7 +49,7 @@ namespace {
 // this value invalidates the gold file and forces a regeneration.
 constexpr uint32_t kAosSeed = 42;
 
-bool loadBin(const std::string& path, pcl::PointCloud<PointXYZILID>::Ptr& cloud) {
+bool loadBin(const std::string& path, travel::PointCloud<PointXYZILID>::Ptr& cloud) {
     std::ifstream f(path, std::ios::binary | std::ios::ate);
     if (!f) { std::cerr << "open failed: " << path << "\n"; return false; }
     std::streamsize bytes = f.tellg();
@@ -76,8 +76,8 @@ bool loadBin(const std::string& path, pcl::PointCloud<PointXYZILID>::Ptr& cloud)
 
 // Build {xyz -> output index} via uint32 bit-pattern hashing. Algorithm
 // copies x/y/z exactly (no projection or quantization), so this is safe.
-std::vector<int> mapToInputIndex(const pcl::PointCloud<PointXYZILID>& input,
-                                 const pcl::PointCloud<PointXYZILID>& out) {
+std::vector<int> mapToInputIndex(const travel::PointCloud<PointXYZILID>& input,
+                                 const travel::PointCloud<PointXYZILID>& out) {
     struct Key { uint32_t x, y, z; };
     struct Hash { size_t operator()(const Key& k) const {
         return (size_t)k.x * 1000003u ^ (size_t)k.y * 7919u ^ (size_t)k.z;
@@ -114,7 +114,7 @@ int main(int argc, char** argv) {
     const std::string out_path  = argv[2];
     const std::string gold_path = (argc == 4) ? argv[3] : "";
 
-    pcl::PointCloud<PointXYZILID>::Ptr cloud_in(new pcl::PointCloud<PointXYZILID>());
+    travel::PointCloud<PointXYZILID>::Ptr cloud_in(new travel::PointCloud<PointXYZILID>());
     if (!loadBin(in_path, cloud_in)) return 2;
     std::cout << "loaded " << cloud_in->size() << " points\n";
 
@@ -127,8 +127,8 @@ int main(int argc, char** argv) {
                   0.5, 0.125, 0.3, 0.940, 200.0,
                   0.03, 0.1, 1.0, /*refine_mode=*/true, /*viz_mode=*/false);
 
-    pcl::PointCloud<PointXYZILID> ground;
-    pcl::PointCloud<PointXYZILID> nonground;
+    travel::PointCloud<PointXYZILID> ground;
+    travel::PointCloud<PointXYZILID> nonground;
     double tgs_time = 0.0;
     tgs.estimateGround(*cloud_in, ground, nonground, tgs_time);
     std::cout << "TGS: ground=" << ground.size()
@@ -139,8 +139,8 @@ int main(int argc, char** argv) {
                   -24.8f, 2.0f, 0.4f, 0.5f, 3, 5, 5, 5, 1, 10, 30000);
     aos.setSeed(kAosSeed);
 
-    pcl::PointCloud<PointXYZILID>::Ptr nonground_ptr(new pcl::PointCloud<PointXYZILID>(nonground));
-    pcl::PointCloud<PointXYZILID>::Ptr labeled_ptr(new pcl::PointCloud<PointXYZILID>());
+    travel::PointCloud<PointXYZILID>::Ptr nonground_ptr(new travel::PointCloud<PointXYZILID>(nonground));
+    travel::PointCloud<PointXYZILID>::Ptr labeled_ptr(new travel::PointCloud<PointXYZILID>());
     aos.segmentObjects(nonground_ptr, labeled_ptr);
     std::cout << "AOS: labeled=" << labeled_ptr->size() << " (seed=" << kAosSeed << ")\n";
 

--- a/cpp/travel/CMakeLists.txt
+++ b/cpp/travel/CMakeLists.txt
@@ -26,13 +26,30 @@ include(GNUInstallDirs)
 list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # --- Dependencies ----------------------------------------------------------
-# Eigen is the only system dep the core needs. PCL and Boost were dropped in
+# Eigen is the only build dep the core needs. PCL and Boost were dropped in
 # the v1.1 release (cpp/travel/core/travel/types.hpp now provides the small
-# slice we used to borrow from PCL). Eigen is header-only and ships
-# everywhere we care about — apt's libeigen3-dev, brew's eigen, vcpkg's
-# eigen3 — so cibuildwheel can produce a Linux/macOS/Windows wheel matrix
-# without per-platform package contortions.
-find_package(Eigen3 REQUIRED NO_MODULE)
+# slice we used to borrow from PCL). We try the system Eigen first
+# (libeigen3-dev / brew eigen / vcpkg eigen3), and fall back to fetching
+# Eigen 3.4.0 directly from GitLab if the system doesn't have it. The
+# fallback covers the manylinux2014 cibuildwheel container (CentOS 7's
+# default repos lack eigen3-devel) and Windows runners that don't have
+# vcpkg pre-installed. Eigen is ~10MB header-only, so the fetch is cheap.
+find_package(Eigen3 NO_MODULE QUIET)
+if (NOT Eigen3_FOUND)
+    message(STATUS "System Eigen3 not found; fetching Eigen 3.4.0 via FetchContent")
+    include(FetchContent)
+    FetchContent_Declare(
+        eigen
+        URL      https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz
+        URL_HASH SHA256=8586084f71f9bde545ee7fa6d00288b264a2b7ac3607b974e54d13e7162c1c72
+    )
+    # Suppress Eigen's own tests / benchmark targets — we only want the
+    # imported `Eigen3::Eigen` interface library.
+    set(EIGEN_BUILD_DOC      OFF CACHE BOOL "" FORCE)
+    set(EIGEN_BUILD_TESTING  OFF CACHE BOOL "" FORCE)
+    set(BUILD_TESTING        OFF CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(eigen)
+endif()
 
 # --- Library target --------------------------------------------------------
 # The TRAVEL core is header-only (templated on PointType), so we expose it as

--- a/cpp/travel/CMakeLists.txt
+++ b/cpp/travel/CMakeLists.txt
@@ -1,9 +1,5 @@
 cmake_minimum_required(VERSION 3.16...3.31)
-# C language is enabled (alongside C++) so find_package(MPI) below can
-# resolve its C component, which VTK 9.1's CMake config needs as MPI::MPI_C
-# when shipped with Ubuntu 22.04's libpcl-dev. We don't actually compile any
-# C source files; this only enables the language for find-time checks.
-project(travel VERSION 1.0.0 LANGUAGES C CXX)
+project(travel VERSION 1.1.0 LANGUAGES CXX)
 
 option(USE_CCACHE "Build using Ccache if found on the path" ON)
 option(TRAVEL_BUILD_EXAMPLES "Build standalone examples in cpp/examples" OFF)
@@ -30,22 +26,18 @@ include(GNUInstallDirs)
 list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # --- Dependencies ----------------------------------------------------------
-# Ubuntu 22.04's libpcl-dev is built against VTK 9.1, whose CMake config
-# advertises VTK::mpi -> MPI::MPI_C without running find_package(MPI)
-# itself. We pre-find MPI here so that imported target exists by the time
-# PCL pulls VTK in. The find is tolerant (no REQUIRED) — older PCL/VTK
-# stacks (macOS Homebrew, Ubuntu 20.04) don't need it and the find is a
-# no-op there.
-find_package(MPI)
-# PCL pulls in Eigen and Boost transitively for the headers we use.
-find_package(PCL REQUIRED COMPONENTS common io filters)
-find_package(Boost REQUIRED COMPONENTS filesystem system)
+# Eigen is the only system dep the core needs. PCL and Boost were dropped in
+# the v1.1 release (cpp/travel/core/travel/types.hpp now provides the small
+# slice we used to borrow from PCL). Eigen is header-only and ships
+# everywhere we care about — apt's libeigen3-dev, brew's eigen, vcpkg's
+# eigen3 — so cibuildwheel can produce a Linux/macOS/Windows wheel matrix
+# without per-platform package contortions.
+find_package(Eigen3 REQUIRED NO_MODULE)
 
 # --- Library target --------------------------------------------------------
 # The TRAVEL core is header-only (templated on PointType), so we expose it as
 # an INTERFACE library. Downstream consumers (ros/, cpp/examples/, python/)
-# link against `travel::travel_core` and inherit the include paths and the
-# transitive PCL/Boost dependencies.
+# link against `travel::travel_core` and inherit the include paths.
 set(TARGET_NAME travel_core)
 add_library(${TARGET_NAME} INTERFACE)
 add_library(travel::travel_core ALIAS ${TARGET_NAME})
@@ -56,17 +48,8 @@ target_include_directories(${TARGET_NAME} INTERFACE
 )
 
 target_link_libraries(${TARGET_NAME} INTERFACE
-    ${PCL_LIBRARIES}
-    Boost::filesystem
-    Boost::system
+    Eigen3::Eigen
 )
-
-target_include_directories(${TARGET_NAME} SYSTEM INTERFACE
-    ${PCL_INCLUDE_DIRS}
-    ${Boost_INCLUDE_DIRS}
-)
-
-target_compile_definitions(${TARGET_NAME} INTERFACE ${PCL_DEFINITIONS})
 
 # --- Examples (opt-in) -----------------------------------------------------
 if (TRAVEL_BUILD_EXAMPLES)

--- a/cpp/travel/cmake/travelConfig.cmake
+++ b/cpp/travel/cmake/travelConfig.cmake
@@ -2,7 +2,9 @@ get_filename_component(TRAVEL_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 list(PREPEND CMAKE_MODULE_PATH "${TRAVEL_CMAKE_DIR}")
 include(CMakeFindDependencyMacro)
 
-find_dependency(PCL REQUIRED COMPONENTS common io filters)
-find_dependency(Boost REQUIRED COMPONENTS filesystem system)
+# Eigen is the sole system dependency from the v1.1 release onward.
+# (Pre-1.1, the core depended on PCL + Boost; that was dropped to make
+# Linux / macOS / Windows wheels feasible without per-platform PCL builds.)
+find_dependency(Eigen3 NO_MODULE)
 
 include("${TRAVEL_CMAKE_DIR}/travelTargets.cmake")

--- a/cpp/travel/core/travel/aos.hpp
+++ b/cpp/travel/core/travel/aos.hpp
@@ -5,15 +5,17 @@
 // We really appreciate Hyungtae Lim and Prof. Hyun Myung! :)
 //
 #pragma once
-#include <vector>
 #include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <forward_list>
 #include <iostream>
 #include <list>
 #include <numeric>
-#include <random>
-#include <chrono>
-#include <forward_list>
 #include <optional>
+#include <random>
+#include <vector>
+
 #include "travel/types.hpp"
 
 #include "travel/logging.hpp"
@@ -30,8 +32,8 @@ namespace travel {
             // and made cluster filtering decisions in labelPointcloud
             // run-to-run nondeterministic. Zero-init makes the algorithm
             // produce the same partition every time the input is the same.
-            uint start = 0;
-            uint end   = 0;
+            std::uint32_t start = 0;
+            std::uint32_t end   = 0;
             int  label;
 
             AOSNode() : label(-1) {}
@@ -40,7 +42,7 @@ namespace travel {
     class Point {
         public:
             float x{0.0f}, y{0.0f}, z{0.0f};
-            uint idx{0};
+            std::uint32_t idx{0};
             bool valid = false;
             int  label{0};
     };
@@ -272,8 +274,8 @@ namespace travel {
             void labelPointcloud(typename travel::PointCloud<T>::Ptr cloud_in,
                                 typename travel::PointCloud<T>::Ptr cloud_out) {
                 num_clusters_ = 0;
-                uint pt_cnt = 0;
-                uint max = 2000;
+                std::uint32_t pt_cnt = 0;
+                std::uint32_t max = 2000;
                 cloud_out->points.reserve(cloud_in->points.size());
 
                 // generate random number

--- a/cpp/travel/core/travel/aos.hpp
+++ b/cpp/travel/core/travel/aos.hpp
@@ -13,12 +13,10 @@
 #include <random>
 #include <chrono>
 #include <forward_list>
-#include <boost/optional.hpp>
+#include <optional>
+#include "travel/types.hpp"
 
 #include "travel/logging.hpp"
-#include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
-#include <pcl/common/io.h>
 
 using namespace std;
 
@@ -73,8 +71,8 @@ namespace travel {
             int DOWNSAMPLE;
             float MIN_VERT_ANGLE;
             float MAX_VERT_ANGLE;
-            boost::optional<int> MIN_CLUSTER_SIZE;
-            boost::optional<int> MAX_CLUSTER_SIZE;
+            std::optional<int> MIN_CLUSTER_SIZE;
+            std::optional<int> MAX_CLUSTER_SIZE;
        
             int num_clusters_ = 0;
 
@@ -112,8 +110,8 @@ namespace travel {
                             float _horz_merge_thres, float _vert_merge_thres, int _vert_scan_size,
                             int _horz_scan_size, int _horz_extension_size, int _horz_skip_size,
                             int _downsample,
-                            boost::optional<int> _min_cluster_size=boost::none, 
-                            boost::optional<int> _max_cluster_size=boost::none) {
+                            std::optional<int> _min_cluster_size=std::nullopt, 
+                            std::optional<int> _max_cluster_size=std::nullopt) {
                             
                 std::cout<<""<<std::endl;
                 TRAVEL_LOG_WARN("Set ObjectSeg Parameters");
@@ -175,8 +173,8 @@ namespace travel {
                     MAX_CLUSTER_SIZE = _max_cluster_size;
             }
 
-            void segmentObjects(typename pcl::PointCloud<T>::Ptr cloud_in,
-                            typename pcl::PointCloud<T>::Ptr cloud_out,
+            void segmentObjects(typename travel::PointCloud<T>::Ptr cloud_in,
+                            typename travel::PointCloud<T>::Ptr cloud_out,
                             vector<float> *vert_angles=nullptr) {
                 // 0. reset
                 max_label_ = 1;
@@ -218,8 +216,8 @@ namespace travel {
                 printf("Post-processing: %ld ms\n", chrono::duration_cast<chrono::milliseconds>(end-start).count());
             }
 
-            void sphericalProjection(typename pcl::PointCloud<T>::Ptr cloud_in) {
-                typename pcl::PointCloud<T>::Ptr valid_cloud(new pcl::PointCloud<T>());
+            void sphericalProjection(typename travel::PointCloud<T>::Ptr cloud_in) {
+                typename travel::PointCloud<T>::Ptr valid_cloud(new travel::PointCloud<T>());
                 valid_cloud->points.reserve(cloud_in->points.size());
                 int ring_idx = -1, row_idx = -1, col_idx = -1;
                 float range;
@@ -271,8 +269,8 @@ namespace travel {
                 *cloud_in = *valid_cloud;
             }
 
-            void labelPointcloud(typename pcl::PointCloud<T>::Ptr cloud_in,
-                                typename pcl::PointCloud<T>::Ptr cloud_out) {
+            void labelPointcloud(typename travel::PointCloud<T>::Ptr cloud_in,
+                                typename travel::PointCloud<T>::Ptr cloud_out) {
                 num_clusters_ = 0;
                 uint pt_cnt = 0;
                 uint max = 2000;

--- a/cpp/travel/core/travel/kitti_loader.hpp
+++ b/cpp/travel/core/travel/kitti_loader.hpp
@@ -1,34 +1,44 @@
 #ifndef TRAVEL_KITTI_LOADER_HPP
 #define TRAVEL_KITTI_LOADER_HPP
 
+// PCL-free, Boost-free KITTI velodyne loader. Uses C++17 <filesystem> and
+// snprintf instead of boost::filesystem / boost::format so the core stays
+// dependency-light enough to ship in a Windows wheel without vcpkg.
+
+#include <cstdio>
+#include <filesystem>
 #include <iostream>
 #include <string>
 #include <vector>
 
-#include <boost/filesystem.hpp>
-#include <boost/format.hpp>
+#include "travel/types.hpp"
 
-#include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
-
-#include "travel/point_types.hpp"
+namespace {
+inline std::string travel_kitti_format_path(const std::string& dir,
+                                            const std::string& ext,
+                                            int idx) {
+    char buf[32];
+    std::snprintf(buf, sizeof(buf), "/%06d.%s", idx, ext.c_str());
+    return dir + buf;
+}
+}  // namespace
 
 class KittiLoader {
 public:
-    KittiLoader(const std::string& abs_path) {
+    explicit KittiLoader(const std::string& abs_path) {
         pc_path_    = abs_path + "/velodyne";
         label_path_ = abs_path + "/labels";
 
         for (num_frames_ = 0;; num_frames_++) {
-            std::string filename = (boost::format("%s/%06d.bin") % pc_path_ % num_frames_).str();
-            if (!boost::filesystem::exists(filename)) {
+            const auto filename = travel_kitti_format_path(pc_path_, "bin", num_frames_);
+            if (!std::filesystem::exists(filename)) {
                 break;
             }
         }
         int num_labels;
         for (num_labels = 0;; num_labels++) {
-            std::string filename = (boost::format("%s/%06d.label") % label_path_ % num_labels).str();
-            if (!boost::filesystem::exists(filename)) {
+            const auto filename = travel_kitti_format_path(label_path_, "label", num_labels);
+            if (!std::filesystem::exists(filename)) {
                 break;
             }
         }
@@ -41,38 +51,39 @@ public:
         }
     }
 
-    ~KittiLoader() {}
+    ~KittiLoader() = default;
 
     size_t size() const { return num_frames_; }
 
-    pcl::PointCloud<pcl::PointXYZI>::ConstPtr cloud(size_t i) const {
-        std::string filename = (boost::format("%s/%06d.bin") % pc_path_ % i).str();
-        FILE* file = fopen(filename.c_str(), "rb");
+    travel::PointCloud<travel::PointXYZI>::ConstPtr cloud(size_t i) const {
+        const auto filename = travel_kitti_format_path(pc_path_, "bin", static_cast<int>(i));
+        FILE* file = std::fopen(filename.c_str(), "rb");
         if (!file) {
             std::cerr << "error: failed to load " << filename << std::endl;
             return nullptr;
         }
 
         std::vector<float> buffer(1000000);  // > 140k * 4 floats
-        size_t num_points = fread(reinterpret_cast<char*>(buffer.data()), sizeof(float), buffer.size(), file) / 4;
-        fclose(file);
+        size_t num_points = std::fread(reinterpret_cast<char*>(buffer.data()),
+                                       sizeof(float), buffer.size(), file) / 4;
+        std::fclose(file);
 
-        pcl::PointCloud<pcl::PointXYZI>::Ptr cloud_ptr(new pcl::PointCloud<pcl::PointXYZI>());
+        auto cloud_ptr = std::make_shared<travel::PointCloud<travel::PointXYZI>>();
         cloud_ptr->resize(num_points);
 
-        for (size_t i = 0; i < num_points; i++) {
-            auto& pt    = cloud_ptr->at(i);
-            pt.x        = buffer[i * 4];
-            pt.y        = buffer[i * 4 + 1];
-            pt.z        = buffer[i * 4 + 2];
-            pt.intensity = buffer[i * 4 + 3];
+        for (size_t k = 0; k < num_points; k++) {
+            auto& pt   = cloud_ptr->at(k);
+            pt.x       = buffer[k * 4];
+            pt.y       = buffer[k * 4 + 1];
+            pt.z       = buffer[k * 4 + 2];
+            pt.intensity = buffer[k * 4 + 3];
         }
 
         return cloud_ptr;
     }
 
 private:
-    int num_frames_;
+    int         num_frames_ = 0;
     std::string label_path_;
     std::string pc_path_;
 };

--- a/cpp/travel/core/travel/point_types.hpp
+++ b/cpp/travel/core/travel/point_types.hpp
@@ -1,42 +1,29 @@
 #ifndef TRAVEL_POINT_TYPES_HPP
 #define TRAVEL_POINT_TYPES_HPP
 
-#include <pcl/point_types.h>
-#include <pcl/point_cloud.h>
+// Backwards-compatibility shim. point_types.hpp used to define PointXYZILID
+// (with PCL macros) and PointXYZILID2XYZI in the global namespace. The
+// algorithm core is now PCL-free; PointXYZILID lives in travel/types.hpp.
+// Existing #include "travel/point_types.hpp" call sites keep working
+// without code changes.
+
+#include "travel/types.hpp"
 
 #define INVALID_IDX -1
 
-struct EIGEN_ALIGN16 PointXYZILID
-{
-  PCL_ADD_POINT4D;                    // quad-word XYZ
-  float    intensity;                 ///< laser intensity reading
-  uint16_t label;                     ///< point label
-  uint16_t id;
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW     // ensure proper alignment
-};
+using num_t = float;
 
-POINT_CLOUD_REGISTER_POINT_STRUCT(PointXYZILID,
-                                  (float, x, x)
-                                  (float, y, y)
-                                  (float, z, z)
-                                  (float, intensity, intensity)
-                                  (uint16_t, label, label)
-                                  (uint16_t, id, id))
-
-using PointT = PointXYZILID;
-using num_t  = float;
-
-inline void PointXYZILID2XYZI(pcl::PointCloud<PointXYZILID>& src,
-                              pcl::PointCloud<pcl::PointXYZI>::Ptr dst) {
-  dst->points.clear();
-  for (const auto& pt : src.points) {
-    pcl::PointXYZI pt_xyzi;
-    pt_xyzi.x         = pt.x;
-    pt_xyzi.y         = pt.y;
-    pt_xyzi.z         = pt.z;
-    pt_xyzi.intensity = pt.intensity;
-    dst->points.push_back(pt_xyzi);
-  }
+inline void PointXYZILID2XYZI(travel::PointCloud<PointXYZILID>&        src,
+                              travel::PointCloud<travel::PointXYZI>::Ptr dst) {
+    dst->points.clear();
+    for (const auto& pt : src.points) {
+        travel::PointXYZI pt_xyzi;
+        pt_xyzi.x         = pt.x;
+        pt_xyzi.y         = pt.y;
+        pt_xyzi.z         = pt.z;
+        pt_xyzi.intensity = pt.intensity;
+        dst->points.push_back(pt_xyzi);
+    }
 }
 
 #endif  // TRAVEL_POINT_TYPES_HPP

--- a/cpp/travel/core/travel/save_labels.hpp
+++ b/cpp/travel/core/travel/save_labels.hpp
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 
-#include <pcl/point_cloud.h>
+#include "travel/types.hpp"
 
 #include "travel/point_types.hpp"
 #include "travel/3rdparty/nanoflann.hpp"
@@ -16,8 +16,8 @@
 template <typename PointType>
 void saveLabels(const std::string abs_dir,
                 const int frame_num,
-                const pcl::PointCloud<PointType>& cloud_in,
-                const pcl::PointCloud<PointType>& labeled_pc) {
+                const travel::PointCloud<PointType>& cloud_in,
+                const travel::PointCloud<PointType>& labeled_pc) {
     // Save labels as a .label file. Compatible with the 3DUIS benchmark
     // (https://codalab.lisn.upsaclay.fr/competitions/2183).
     // Labels are taken from the intensity of `labeled_pc` (must be > 0).

--- a/cpp/travel/core/travel/tgs.hpp
+++ b/cpp/travel/core/travel/tgs.hpp
@@ -17,12 +17,7 @@
 #include <queue>
 #include <signal.h>
 
-#include <pcl/filters/filter.h>
-#include <pcl/common/centroid.h>
-#include <pcl/filters/voxel_grid.h>
-#include <pcl/PCLHeader.h>
-#include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
+#include "travel/types.hpp"
 
 #include "travel/logging.hpp"
 
@@ -56,7 +51,7 @@ namespace travel {
     template <typename PointType>
     struct TriGridNode {
         int node_type;
-        pcl::PointCloud<PointType> ptCloud;
+        travel::PointCloud<PointType> ptCloud;
 
         bool is_curr_data;
         
@@ -95,7 +90,7 @@ namespace travel {
     template <typename PointType>
     class TravelGroundSeg{
     private:
-        pcl::PCLHeader cloud_header_;
+        travel::PCLHeader cloud_header_;
 
         bool REFINE_MODE_;
         bool VIZ_MDOE_;
@@ -123,20 +118,20 @@ namespace travel {
         std::vector<std::vector<TriGridCorner>> trigrid_corners_;
         std::vector<std::vector<TriGridCorner>> trigrid_centers_;
 
-        pcl::PointCloud<PointType> empty_cloud_;
+        travel::PointCloud<PointType> empty_cloud_;
         TriGridNode<PointType>  empty_trigrid_node_;
         GridNode<PointType> empty_grid_nodes_;
         TriGridCorner empty_trigrid_corner_;
         TriGridCorner empty_trigrid_center_;
 
-        pcl::PointCloud<PointType> ptCloud_tgfwise_ground_;
-        pcl::PointCloud<PointType> ptCloud_tgfwise_nonground_;
-        pcl::PointCloud<PointType> ptCloud_tgfwise_outliers_;
-        pcl::PointCloud<PointType> ptCloud_tgfwise_obstacle_;
-        pcl::PointCloud<PointType> ptCloud_nodewise_ground_;
-        pcl::PointCloud<PointType> ptCloud_nodewise_nonground_;
-        pcl::PointCloud<PointType> ptCloud_nodewise_outliers_;
-        pcl::PointCloud<PointType> ptCloud_nodewise_obstacle_;
+        travel::PointCloud<PointType> ptCloud_tgfwise_ground_;
+        travel::PointCloud<PointType> ptCloud_tgfwise_nonground_;
+        travel::PointCloud<PointType> ptCloud_tgfwise_outliers_;
+        travel::PointCloud<PointType> ptCloud_tgfwise_obstacle_;
+        travel::PointCloud<PointType> ptCloud_nodewise_ground_;
+        travel::PointCloud<PointType> ptCloud_nodewise_nonground_;
+        travel::PointCloud<PointType> ptCloud_nodewise_outliers_;
+        travel::PointCloud<PointType> ptCloud_nodewise_obstacle_;
 
     public:
         TravelGroundSeg() {
@@ -223,9 +218,9 @@ namespace travel {
             // the graph via getTriGridField() / getTriGridEdges().
         }
 
-        void estimateGround(const pcl::PointCloud<PointType>& cloud_in,
-                            pcl::PointCloud<PointType>& cloudGround_out,
-                            pcl::PointCloud<PointType>& cloudNonground_out,
+        void estimateGround(const travel::PointCloud<PointType>& cloud_in,
+                            travel::PointCloud<PointType>& cloudGround_out,
+                            travel::PointCloud<PointType>& cloudNonground_out,
                             double& time_taken){
         
             // 0. Init
@@ -321,8 +316,8 @@ namespace travel {
             }
         };
 
-        pcl::PointCloud<PointType> getObstaclePC(){
-            pcl::PointCloud<PointType> cloud_obstacle;
+        travel::PointCloud<PointType> getObstaclePC(){
+            travel::PointCloud<PointType> cloud_obstacle;
             cloud_obstacle = ptCloud_tgfwise_obstacle_;
             return cloud_obstacle;
         };
@@ -474,7 +469,7 @@ namespace travel {
             return false;
         }
 
-        void embedCloudToTriGridField(const pcl::PointCloud<PointType>& cloud_in, TriGridField<PointType>& tgf_out) {
+        void embedCloudToTriGridField(const travel::PointCloud<PointType>& cloud_in, TriGridField<PointType>& tgf_out) {
             // TRAVEL_LOG_INFO("Embedding PointCloud to TriGridField...");
 
             for (auto const &pt: cloud_in.points){
@@ -515,7 +510,7 @@ namespace travel {
             return;
         };
 
-        void extractInitialSeeds(const pcl::PointCloud<PointType>& p_sorted, pcl::PointCloud<PointType>& init_seeds){
+        void extractInitialSeeds(const travel::PointCloud<PointType>& p_sorted, travel::PointCloud<PointType>& init_seeds){
             //function for uniform mode
             init_seeds.points.clear();
 
@@ -541,12 +536,12 @@ namespace travel {
             return;
         }
 
-        void estimatePlanarModel(const pcl::PointCloud<PointType>& ground_in, TriGridNode<PointType>& node_out) {
+        void estimatePlanarModel(const travel::PointCloud<PointType>& ground_in, TriGridNode<PointType>& node_out) {
 
             // function for uniform mode
             Eigen::Matrix3f cov_;
             Eigen::Vector4f pc_mean_;
-            pcl::computeMeanAndCovarianceMatrix(ground_in, cov_, pc_mean_);
+            travel::computeMeanAndCovarianceMatrix(ground_in, cov_, pc_mean_);
 
             // Singular Value Decomposition: SVD
             Eigen::JacobiSVD<Eigen::MatrixXf> svd(cov_, Eigen::DecompositionOptions::ComputeFullU);
@@ -579,7 +574,7 @@ namespace travel {
             
             // Tri Grid Initialization
             // When to initialize the planar model, we don't have prior. so outlier is removed in heuristic parameter.
-            pcl::PointCloud<PointType> sort_ptCloud = node_in.ptCloud;
+            travel::PointCloud<PointType> sort_ptCloud = node_in.ptCloud;
 
             // sort in z-coordinate
             sort(sort_ptCloud.points.begin(), sort_ptCloud.end(), point_z_cmp<PointType>);
@@ -965,7 +960,7 @@ namespace travel {
         };
 
 
-        double getCornerWeight(const TriGridNode<PointType>& node_in, const pcl::PointXYZ &tgt_corner){
+        double getCornerWeight(const TriGridNode<PointType>& node_in, const travel::PointXYZ &tgt_corner){
             double xy_dist = sqrt( (node_in.mean_pt[0]-tgt_corner.x)*(node_in.mean_pt[0]-tgt_corner.x)+(node_in.mean_pt[1]-tgt_corner.y)*(node_in.mean_pt[1]-tgt_corner.y) );
             return (node_in.weight/xy_dist);
         }
@@ -973,7 +968,7 @@ namespace travel {
         void setTGFCornersCenters(const TriGridField<PointType>& tgf_in,
                                 std::vector<std::vector<TriGridCorner>>& trigrid_corners_out,
                                 std::vector<std::vector<TriGridCorner>>& trigrid_centers_out) {
-            pcl::PointXYZ corner_TL, corner_BL, corner_BR, corner_TR, corner_C;
+            travel::PointXYZ corner_TL, corner_BL, corner_BR, corner_TR, corner_C;
 
             for (int r_i = 0; r_i<rows_; r_i++){
             for (int c_i = 0; c_i<cols_; c_i++){
@@ -1217,10 +1212,10 @@ namespace travel {
         };
 
         void segmentNodeGround(const TriGridNode<PointType>& node_in,
-                                pcl::PointCloud<PointType>& node_ground_out,
-                                pcl::PointCloud<PointType>& node_nonground_out,
-                                pcl::PointCloud<PointType>& node_obstacle_out,
-                                pcl::PointCloud<PointType>& node_outlier_out) {
+                                travel::PointCloud<PointType>& node_ground_out,
+                                travel::PointCloud<PointType>& node_nonground_out,
+                                travel::PointCloud<PointType>& node_obstacle_out,
+                                travel::PointCloud<PointType>& node_outlier_out) {
             node_ground_out.clear();
             node_nonground_out.clear();
             node_obstacle_out.clear();
@@ -1254,10 +1249,10 @@ namespace travel {
         }
 
         void segmentTGFGround(const TriGridField<PointType>& tgf_in, 
-                        pcl::PointCloud<PointType>& ground_cloud_out, 
-                        pcl::PointCloud<PointType>& nonground_cloud_out,
-                        pcl::PointCloud<PointType>& obstacle_cloud_out,
-                        pcl::PointCloud<PointType>& outlier_cloud_out) {
+                        travel::PointCloud<PointType>& ground_cloud_out, 
+                        travel::PointCloud<PointType>& nonground_cloud_out,
+                        travel::PointCloud<PointType>& obstacle_cloud_out,
+                        travel::PointCloud<PointType>& outlier_cloud_out) {
             ground_cloud_out.clear();
             nonground_cloud_out.clear();
             obstacle_cloud_out.clear();
@@ -1290,16 +1285,16 @@ namespace travel {
         };
 
         void segmentTGFGround_developing(const TriGridField<PointType>& tgf_in, 
-                        pcl::PointCloud<PointType>& ground_cloud_out, 
-                        pcl::PointCloud<PointType>& nonground_cloud_out,
-                        pcl::PointCloud<PointType>& obstacle_cloud_out,
-                        pcl::PointCloud<PointType>& outlier_cloud_out) {
+                        travel::PointCloud<PointType>& ground_cloud_out, 
+                        travel::PointCloud<PointType>& nonground_cloud_out,
+                        travel::PointCloud<PointType>& obstacle_cloud_out,
+                        travel::PointCloud<PointType>& outlier_cloud_out) {
             ground_cloud_out.clear();
             nonground_cloud_out.clear();
             obstacle_cloud_out.clear();
             TriGridIdx curr_tgf_idx;
             std::vector<TriGridIdx> adj_idx_vec;
-            pcl::PointCloud<PointType> outlier_tmp;
+            travel::PointCloud<PointType> outlier_tmp;
             outlier_tmp.clear();
             outlier_tmp.reserve(NODEWISE_PTCLOUDSIZE);
             for (int r_i = 0; r_i < rows_; r_i++){

--- a/cpp/travel/core/travel/types.hpp
+++ b/cpp/travel/core/travel/types.hpp
@@ -25,6 +25,13 @@
 
 #include <Eigen/Core>
 
+// MSVC's <cmath> does not define M_PI by default (POSIX/GNU extension);
+// the algorithm uses M_PI in several places, so we define it here once,
+// in the header that every other core header transitively includes.
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
 namespace travel {
 
 // PCL's PCLHeader is essentially this. Some PCL code reads `seq`, `stamp`,

--- a/cpp/travel/core/travel/types.hpp
+++ b/cpp/travel/core/travel/types.hpp
@@ -1,0 +1,192 @@
+#ifndef TRAVEL_TYPES_HPP
+#define TRAVEL_TYPES_HPP
+
+// Self-contained replacements for the small slice of PCL the algorithm
+// previously borrowed. Keeping the core PCL-free lets `pip install travel-seg`
+// produce prebuilt wheels for macOS / Linux / Windows without dragging in a
+// PCL system install at every install site.
+//
+// What we replicate:
+//   - travel::PCLHeader            ↔ pcl::PCLHeader   (POD timestamp/frame)
+//   - travel::PointCloud<T>        ↔ pcl::PointCloud<T>  (vector-with-header)
+//   - travel::PointXYZ / XYZI      ↔ pcl::PointXYZ / pcl::PointXYZI
+//   - PointXYZILID                 (custom point type used by TGS/AOS)
+//   - travel::computeMeanAndCovarianceMatrix
+//                                  ↔ pcl::computeMeanAndCovarianceMatrix
+//
+// The cov-matrix routine ports PCL's accumulator pattern bit-for-bit, in
+// exactly the same float order, so KITTI regression bit-identity is
+// preserved. See cpp/tests/data/kitti00_000000_gold.bin.
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <Eigen/Core>
+
+namespace travel {
+
+// PCL's PCLHeader is essentially this. Some PCL code reads `seq`, `stamp`,
+// `frame_id`; we only need it as a passthrough for cloud_header_ inside TGS.
+struct PCLHeader {
+    std::uint32_t seq    = 0;
+    std::uint64_t stamp  = 0;
+    std::string   frame_id;
+};
+
+// PCL-compatible vector-with-header container. The API is intentionally
+// minimal — only the surface our algorithm and tests actually call.
+template <typename PointT>
+struct PointCloud {
+    using value_type = PointT;
+    using Ptr        = std::shared_ptr<PointCloud<PointT>>;
+    using ConstPtr   = std::shared_ptr<const PointCloud<PointT>>;
+
+    PCLHeader            header;
+    std::vector<PointT>  points;
+    std::uint32_t        width    = 0;
+    std::uint32_t        height   = 1;
+    bool                 is_dense = true;
+
+    PointCloud() = default;
+    PointCloud(const PointCloud&)     = default;
+    PointCloud(PointCloud&&) noexcept = default;
+    PointCloud& operator=(const PointCloud&)     = default;
+    PointCloud& operator=(PointCloud&&) noexcept = default;
+
+    std::size_t size()  const noexcept { return points.size(); }
+    bool        empty() const noexcept { return points.empty(); }
+
+    void clear()          noexcept { points.clear(); width = 0; }
+    void reserve(std::size_t n)    { points.reserve(n); }
+    void resize(std::size_t n)     { points.resize(n); width = static_cast<std::uint32_t>(points.size()); }
+
+    void push_back(const PointT& p)    { points.push_back(p);    width = static_cast<std::uint32_t>(points.size()); }
+    void push_back(PointT&& p)         { points.push_back(std::move(p)); width = static_cast<std::uint32_t>(points.size()); }
+    template <typename... Args>
+    void emplace_back(Args&&... args)  { points.emplace_back(std::forward<Args>(args)...); width = static_cast<std::uint32_t>(points.size()); }
+
+    PointT&       operator[](std::size_t i)       { return points[i]; }
+    const PointT& operator[](std::size_t i) const { return points[i]; }
+    PointT&       at(std::size_t i)               { return points.at(i); }
+    const PointT& at(std::size_t i) const         { return points.at(i); }
+
+    typename std::vector<PointT>::iterator       begin()       { return points.begin(); }
+    typename std::vector<PointT>::iterator       end()         { return points.end(); }
+    typename std::vector<PointT>::const_iterator begin() const { return points.begin(); }
+    typename std::vector<PointT>::const_iterator end()   const { return points.end(); }
+
+    PointCloud<PointT>& operator+=(const PointCloud<PointT>& other) {
+        points.insert(points.end(), other.points.begin(), other.points.end());
+        width = static_cast<std::uint32_t>(points.size());
+        return *this;
+    }
+};
+
+// Plain XYZ point — used by KittiLoader's intermediate cloud.
+struct PointXYZ {
+    float x{0.0f}, y{0.0f}, z{0.0f};
+};
+
+// XYZ + intensity — KittiLoader output.
+struct PointXYZI {
+    float x{0.0f}, y{0.0f}, z{0.0f};
+    float intensity{0.0f};
+};
+
+// Port of PCL's `pcl::computeMeanAndCovarianceMatrix(cloud, cov, centroid)`.
+//
+// Same accumulator order, same single-pass formulation, same Eigen storage
+// layout (1x9 row-major) as PCL's specialization for pcl::PointCloud<T>.
+// Verified bit-identical against the pre-port build via the KITTI gold
+// regression in cpp/tests/regression_kitti.cpp.
+template <typename PointT>
+inline unsigned int computeMeanAndCovarianceMatrix(
+    const PointCloud<PointT>& cloud,
+    Eigen::Matrix3f&          covariance_matrix,
+    Eigen::Vector4f&          centroid)
+{
+    if (cloud.empty()) return 0u;
+
+    Eigen::Matrix<float, 1, 9, Eigen::RowMajor> accu = Eigen::Matrix<float, 1, 9, Eigen::RowMajor>::Zero();
+    std::size_t point_count = 0;
+
+    if (cloud.is_dense) {
+        point_count = cloud.size();
+        for (const auto& p : cloud.points) {
+            accu[0] += p.x * p.x;
+            accu[1] += p.x * p.y;
+            accu[2] += p.x * p.z;
+            accu[3] += p.y * p.y;
+            accu[4] += p.y * p.z;
+            accu[5] += p.z * p.z;
+            accu[6] += p.x;
+            accu[7] += p.y;
+            accu[8] += p.z;
+        }
+    } else {
+        for (const auto& p : cloud.points) {
+            if (!std::isfinite(p.x) || !std::isfinite(p.y) || !std::isfinite(p.z)) continue;
+            accu[0] += p.x * p.x;
+            accu[1] += p.x * p.y;
+            accu[2] += p.x * p.z;
+            accu[3] += p.y * p.y;
+            accu[4] += p.y * p.z;
+            accu[5] += p.z * p.z;
+            accu[6] += p.x;
+            accu[7] += p.y;
+            accu[8] += p.z;
+            ++point_count;
+        }
+    }
+
+    accu /= static_cast<float>(point_count);
+
+    centroid[0] = accu[6];
+    centroid[1] = accu[7];
+    centroid[2] = accu[8];
+    centroid[3] = 1.0f;
+
+    // Eigen::Matrix3f is column-major by default; coeffRef indexing matches
+    // the PCL code we ported from. The mapping: 0=(0,0), 1=(1,0), 2=(2,0),
+    // 3=(0,1), 4=(1,1), 5=(2,1), 6=(0,2), 7=(1,2), 8=(2,2).
+    covariance_matrix.coeffRef(0) = accu[0] - accu[6] * accu[6];
+    covariance_matrix.coeffRef(1) = accu[1] - accu[6] * accu[7];
+    covariance_matrix.coeffRef(2) = accu[2] - accu[6] * accu[8];
+    covariance_matrix.coeffRef(4) = accu[3] - accu[7] * accu[7];
+    covariance_matrix.coeffRef(5) = accu[4] - accu[7] * accu[8];
+    covariance_matrix.coeffRef(8) = accu[5] - accu[8] * accu[8];
+    covariance_matrix.coeffRef(3) = covariance_matrix.coeff(1);
+    covariance_matrix.coeffRef(6) = covariance_matrix.coeff(2);
+    covariance_matrix.coeffRef(7) = covariance_matrix.coeff(5);
+
+    return static_cast<unsigned int>(point_count);
+}
+
+}  // namespace travel
+
+// PointXYZILID stays in the global namespace because the algorithm
+// templates and downstream call sites have always referred to it bare.
+// The PCL macros (PCL_ADD_POINT4D, POINT_CLOUD_REGISTER_POINT_STRUCT) are
+// dropped — TRAVEL never relied on PCL's runtime point-field registry,
+// only on the field layout matching pcl::PointXYZI. The 16-byte first
+// chunk preserves the PCL_ADD_POINT4D layout (3 floats + 1 padding/data[3])
+// so any downstream code that read PointXYZILID via a memcpy of XYZ still
+// sees the same bytes.
+struct alignas(16) PointXYZILID {
+    union {
+        float data[4];
+        struct { float x, y, z; float data_w; };
+    };
+    float          intensity;
+    std::uint16_t  label;
+    std::uint16_t  id;
+};
+
+// `using PointT = PointXYZILID;` was set in the old utils.hpp. Keep the
+// alias here so existing call sites (especially in cpp/examples and ROS
+// wrapper) compile unchanged.
+using PointT = PointXYZILID;
+
+#endif  // TRAVEL_TYPES_HPP

--- a/python/README.md
+++ b/python/README.md
@@ -4,28 +4,32 @@ Python bindings for [TRAVEL](https://github.com/url-kaist/TRAVEL) — traversabl
 
 ## Install
 
-### From source (development)
-
-```bash
-# System deps (Ubuntu)
-sudo apt install build-essential cmake libeigen3-dev libpcl-dev \
-                 libboost-system-dev libboost-filesystem-dev
-
-# System deps (macOS)
-brew install cmake eigen boost pcl
-
-git clone https://github.com/url-kaist/TRAVEL.git
-cd TRAVEL
-pip install -e python/
-```
-
-### From PyPI
+### From PyPI (recommended)
 
 ```bash
 pip install travel-seg
 ```
 
-The PyPI sdist's `python/CMakeLists.txt` falls back to `FetchContent` for the C++ core, so no separate clone is needed. System-side, you still need PCL + Boost + Eigen on the build path — see the system-deps lines in the source-install block above.
+Prebuilt wheels are published for **Linux x86_64 (manylinux_2_17), macOS arm64 + x86_64, and Windows x86_64** for CPython 3.8–3.13. As of v1.1, the only system dependency is Eigen — no PCL / Boost install required.
+
+### From source (development)
+
+```bash
+# System deps (Ubuntu)
+sudo apt install build-essential cmake libeigen3-dev
+
+# System deps (macOS)
+brew install cmake eigen
+
+# System deps (Windows)
+vcpkg install eigen3:x64-windows
+# then: -DCMAKE_PREFIX_PATH="C:/vcpkg/installed/x64-windows" forwarded by
+# the release workflow / pip env on Windows.
+
+git clone https://github.com/url-kaist/TRAVEL.git
+cd TRAVEL
+pip install -e python/
+```
 
 ## Usage
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "travel-seg"
-version = "1.0.0"
+version = "1.1.0"
 requires-python = ">=3.8"
 description = "Python bindings for TRAVEL: traversable ground and above-ground object segmentation for 3D LiDAR scans"
 readme = "README.md"

--- a/python/travel_seg/__init__.py
+++ b/python/travel_seg/__init__.py
@@ -19,7 +19,7 @@ Quick start::
 from ._api import ObjectCluster, TravelGroundSeg, segment
 from ._config import GroundSegConfig, ObjectClusterConfig, SegmentResult
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 __all__ = [
     "GroundSegConfig",

--- a/python/travel_seg/pybind/travel_pybind.cpp
+++ b/python/travel_seg/pybind/travel_pybind.cpp
@@ -26,8 +26,6 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
-#include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
 
 #include "travel/3rdparty/nanoflann.hpp"
 #include "travel/3rdparty/nanoflann_utils.hpp"
@@ -40,7 +38,7 @@ using namespace py::literals;
 
 namespace {
 
-using Cloud    = pcl::PointCloud<PointXYZILID>;
+using Cloud    = travel::PointCloud<PointXYZILID>;
 using CloudPtr = Cloud::Ptr;
 
 // Convert numpy [N,3] (XYZ) or [N,4] (XYZI) float32 array -> PCL cloud.
@@ -151,7 +149,7 @@ PYBIND11_MODULE(_travel_seg, m) {
     m.doc() =
         "pybind11 bindings for the TRAVEL traversable-ground / object "
         "segmentation library.";
-    m.attr("__version__") = "1.0.0";
+    m.attr("__version__") = "1.1.0";
 
     // -- TravelGroundSeg ------------------------------------------------------
     py::class_<travel::TravelGroundSeg<PointXYZILID>>(m, "_TravelGroundSeg")

--- a/python/travel_seg/pybind/travel_pybind.cpp
+++ b/python/travel_seg/pybind/travel_pybind.cpp
@@ -53,13 +53,13 @@ CloudPtr numpyToCloud(py::array_t<float, py::array::c_style | py::array::forceca
             "expected (N, 3) for XYZ or (N, 4) for XYZI, got shape (" +
             std::to_string(info.shape[0]) + ", " + std::to_string(info.shape[1]) + ")");
     }
-    const ssize_t N    = info.shape[0];
-    const ssize_t cols = info.shape[1];
+    const py::ssize_t N    = info.shape[0];
+    const py::ssize_t cols = info.shape[1];
     const float*  data = static_cast<const float*>(info.ptr);
 
     CloudPtr cloud(new Cloud());
     cloud->reserve(static_cast<size_t>(N));
-    for (ssize_t i = 0; i < N; ++i) {
+    for (py::ssize_t i = 0; i < N; ++i) {
         PointXYZILID p{};
         p.x         = data[i * cols + 0];
         p.y         = data[i * cols + 1];

--- a/ros/src/travel_node.cpp
+++ b/ros/src/travel_node.cpp
@@ -124,13 +124,18 @@ public:
 
 private:
     void cloudCallback(const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg) {
-        // 1. Convert ROS message -> our PointXYZILID cloud, range-filtering
-        //    on the fly so out-of-range and NaN points are dropped before
-        //    they reach the algorithm.
+        // The travel core stopped using PCL types in v1.1, so this wrapper
+        // does the PCL <-> travel conversion at the ROS boundary. PCL stays
+        // in this file (we still need pcl::fromROSMsg / pcl::toROSMsg),
+        // it just doesn't leak into the algorithm any more.
+
+        // 1. ROS message -> pcl::PointXYZ buffer for cheap deserialization,
+        //    then funnel into a travel::PointCloud<PointXYZILID> with the
+        //    range / NaN filter applied on the fly.
         pcl::PointCloud<pcl::PointXYZ> raw;
         pcl::fromROSMsg(*msg, raw);
 
-        pcl::PointCloud<PointT>::Ptr cloud_in(new pcl::PointCloud<PointT>());
+        auto cloud_in = std::make_shared<travel::PointCloud<PointT>>();
         cloud_in->reserve(raw.size());
         for (const auto& p : raw.points) {
             if (!std::isfinite(p.x) || !std::isfinite(p.y) || !std::isfinite(p.z)) continue;
@@ -143,14 +148,14 @@ private:
         }
 
         // 2. Ground segmentation
-        pcl::PointCloud<PointT> ground, nonground;
+        travel::PointCloud<PointT> ground, nonground;
         double tgs_time = 0.0;
         const auto t0 = std::chrono::steady_clock::now();
         tgs_.estimateGround(*cloud_in, ground, nonground, tgs_time);
 
         // 3. Object clustering on the non-ground subset
-        pcl::PointCloud<PointT>::Ptr nonground_ptr(new pcl::PointCloud<PointT>(nonground));
-        pcl::PointCloud<PointT>::Ptr labeled_ptr(new pcl::PointCloud<PointT>());
+        auto nonground_ptr = std::make_shared<travel::PointCloud<PointT>>(nonground);
+        auto labeled_ptr   = std::make_shared<travel::PointCloud<PointT>>();
         aos_.segmentObjects(nonground_ptr, labeled_ptr);
         const auto t1 = std::chrono::steady_clock::now();
         const double total_ms =
@@ -158,9 +163,9 @@ private:
 
         // 4. Publish all three streams. Headers carry the input timestamp /
         //    frame_id so tooling stays in sync.
-        publishCloud(*pub_ground_,    ground,        msg->header);
-        publishCloud(*pub_nonground_, nonground,     msg->header);
-        publishCloud(*pub_labeled_,   *labeled_ptr,  msg->header);
+        publishCloud(*pub_ground_,    ground,        msg->header, /*emit_label=*/false);
+        publishCloud(*pub_nonground_, nonground,     msg->header, /*emit_label=*/false);
+        publishCloud(*pub_labeled_,   *labeled_ptr,  msg->header, /*emit_label=*/true);
 
         RCLCPP_DEBUG(get_logger(),
                      "in=%zu ground=%zu nonground=%zu labeled=%zu  total=%.2fms",
@@ -168,12 +173,43 @@ private:
                      labeled_ptr->size(), total_ms);
     }
 
+    // Converts a travel::PointCloud<PointXYZILID> to a sensor_msgs PointCloud2.
+    // Uses PCL types under the hood for the field-layout machinery that
+    // pcl::toROSMsg expects:
+    //   * ground / nonground -> pcl::PointXYZI (intensity carries the
+    //     algorithm-input intensity, currently 0).
+    //   * labeled            -> pcl::PointXYZL (label carries the cluster id).
     void publishCloud(rclcpp::Publisher<sensor_msgs::msg::PointCloud2>& pub,
-                      const pcl::PointCloud<PointT>& cloud,
-                      const std_msgs::msg::Header& header) {
+                      const travel::PointCloud<PointT>& cloud,
+                      const std_msgs::msg::Header& header,
+                      bool emit_label) {
         if (pub.get_subscription_count() == 0) return;
         auto msg = std::make_unique<sensor_msgs::msg::PointCloud2>();
-        pcl::toROSMsg(cloud, *msg);
+        if (emit_label) {
+            pcl::PointCloud<pcl::PointXYZL> out;
+            out.points.reserve(cloud.size());
+            for (const auto& p : cloud.points) {
+                pcl::PointXYZL q;
+                q.x = p.x; q.y = p.y; q.z = p.z;
+                q.label = p.id;
+                out.points.push_back(q);
+            }
+            out.width = static_cast<std::uint32_t>(out.points.size());
+            out.height = 1;
+            pcl::toROSMsg(out, *msg);
+        } else {
+            pcl::PointCloud<pcl::PointXYZI> out;
+            out.points.reserve(cloud.size());
+            for (const auto& p : cloud.points) {
+                pcl::PointXYZI q;
+                q.x = p.x; q.y = p.y; q.z = p.z;
+                q.intensity = p.intensity;
+                out.points.push_back(q);
+            }
+            out.width = static_cast<std::uint32_t>(out.points.size());
+            out.height = 1;
+            pcl::toROSMsg(out, *msg);
+        }
         msg->header = header;
         pub.publish(std::move(msg));
     }


### PR DESCRIPTION
Plan A from the wheel-matrix discussion: rather than fight per-platform PCL installs (vcpkg PCL alone makes a Windows wheel build ~30 min), strip PCL + Boost out of the algorithm core. The core only borrowed a tiny slice of PCL — type wrappers, plus a single algorithm call to \`pcl::computeMeanAndCovarianceMatrix\`. Replacing those is contained.

## Why

Goal: \`pip install travel-seg\` on **macOS arm64 / Linux x86_64 / Windows x86_64** all picks up a prebuilt wheel for CPython 3.8–3.13. Patchwork++ already does this; it's possible because that project only depends on Eigen. After this PR, travel-seg is in the same bucket.

## What changed in the core

- **New \`travel/types.hpp\`** with the slice of PCL we used to borrow:
  - \`travel::PCLHeader\`, \`travel::PointCloud<T>\` (vector-with-header container with the PCL-shaped API surface we actually call)
  - \`travel::PointXYZ\`, \`travel::PointXYZI\` (POD)
  - Global \`PointXYZILID\` retained, but the \`PCL_ADD_POINT4D\` macro replaced with the equivalent anonymous union, and the \`POINT_CLOUD_REGISTER_POINT_STRUCT\` registry call dropped.
  - \`travel::computeMeanAndCovarianceMatrix\` ports PCL's accumulator pattern bit-for-bit: same Eigen 1×9 row-major storage, same single-pass formulation, same float order, same \`coeffRef\` indices.
- \`tgs.hpp\` / \`aos.hpp\` / \`save_labels.hpp\` / \`kitti_loader.hpp\` now refer to \`travel::PointCloud<...>\` and \`travel::computeMeanAndCovarianceMatrix\`.
- \`aos.hpp\` swapped \`boost::optional<int>\` for C++17 \`std::optional<int>\`.
- \`kitti_loader.hpp\` swapped \`boost::filesystem\` + \`boost::format\` for \`<filesystem>\` + \`snprintf\`.
- \`cpp/travel/CMakeLists.txt\` only does \`find_package(Eigen3)\` now. PCL, Boost, MPI/VTK workarounds gone. Project version 1.1.0.

## Why this is safe under the "never break the pipeline" rule

The fix preserves byte-for-byte output. \`computeMeanAndCovarianceMatrix\` was the one real PCL algorithm call; the port keeps the exact float-arithmetic order PCL used.

\`\`\`
$ ./build/tests/regression_kitti kitti00_000000.bin /tmp/run.bin cpp/tests/data/kitti00_000000_gold.bin
REGRESSION PASS: bit-identical to cpp/tests/data/kitti00_000000_gold.bin (374008 bytes)
\`\`\`

Verified bit-identical on:
- macOS arm64 + Apple Silicon Homebrew clang + Eigen 3.4.0
- Ubuntu 24.04 + GCC 13.3 + libeigen3-dev (linux/arm64 docker)

Python: \`pytest python/tests/\` -> 7/7 passed on macOS arm64.

## ROS wrapper

\`ros/\` keeps PCL — it still needs \`pcl::fromROSMsg\` / \`pcl::toROSMsg\` for ROS message conversion. The boundary in \`ros/src/travel_node.cpp\` now converts \`pcl::PointCloud<pcl::PointXYZ>\` → \`travel::PointCloud<PointXYZILID>\` on input, and copies the algorithm output back out into \`pcl::PointXYZI\` / \`pcl::PointXYZL\` clouds for the publish path. PCL stays a *ros wrapper* dependency, not a *core* dependency.

## Wheel matrix

\`.github/workflows/release.yml\` rewritten to a cibuildwheel matrix:
- \`ubuntu-22.04\` runner → manylinux_2_17 x86_64 wheels (cibuildwheel runs the build inside the manylinux container).
- \`macos-14\` runner → arm64 + x86_64 wheels (cross-compile via \`CIBW_ARCHS_MACOS\`).
- \`windows-2022\` runner → win_amd64 wheel.
- \`CIBW_BEFORE_ALL_LINUX="yum install -y eigen3-devel"\`, macOS \`brew install eigen\`, Windows \`vcpkg install eigen3:x64-windows\` with \`CMAKE_PREFIX_PATH\` forwarded.
- \`CIBW_SKIP="pp* *-musllinux_*"\` — CPython + manylinux only.
- Trusted-Publisher PyPI upload only when run from a git tag (\`v*\`).

## Test plan

- [ ] CI green across all 6 jobs (KITTI bit-compare in particular).
- [ ] Release workflow run on this PR's HEAD: produces sdist + Linux/macOS/Windows wheels under \`wheelhouse/\` (no upload, just artefact build) and twine-checks them.
- [ ] After merge: \`git tag v1.1.0 && git push origin v1.1.0\` → release workflow builds wheels and uploads them to PyPI via the existing pending publisher.
- [ ] Fresh-venv install on a Windows machine: \`pip install travel-seg==1.1.0\` lands a prebuilt \`win_amd64\` wheel (no source build).